### PR TITLE
logging improvements

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -37,24 +37,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:30067e5e846b308b99ca87413b240589a3f063cee98257632798cc2282d280ce",
-                "sha256:7e0d026ff9e2c2628dc2cbbd42feea053205f55e316f76e79dd9e2018d78b577"
+                "sha256:42f880165290d1eff48e4cca1d7577fb98ee75d5dd295cf63a2963ffa2569137",
+                "sha256:d1d2f8defdf83e2d405ca909f94b1007f85edaf1cf7d92cebde69fc480fbf7a9"
             ],
-            "version": "==1.18.93"
+            "version": "==1.18.94"
         },
         "boto3": {
             "hashes": [
-                "sha256:c2a223f4b48782e8b160b2130265e2a66081df111f630a5a384d6909e29a5aa9",
-                "sha256:ce5a4ab6af9e993d1864209cbbb6f4812f65fbc57ad6b95e5967d8bf38b1dcfb"
+                "sha256:ae57df1fbad7e29954a160d77cbf650d6562eb0d304c1206afa71d914e771a66",
+                "sha256:cbe618d61cb8f75cd9495ea36e69bad7c8984eb11f02ad247be4c9a2eb7eb647"
             ],
-            "version": "==1.14.16"
+            "version": "==1.14.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:99d995ef99cf77458a661f3fc64e0c3a4ce77ca30facfdf0472f44b2953dd856",
-                "sha256:fe0c4f7cd6b67eff3b7cb8dff6709a65d6fca10b7b7449a493b2036915e98b4c"
+                "sha256:5528c04c360019c24f2706ce82872c9ab767a8c581beffdfdaf006cce7499cac",
+                "sha256:d65b5574dad8c221344496352245828d9ffecaa0868199eb04ccd2eb2ff09133"
             ],
-            "version": "==1.17.16"
+            "version": "==1.17.17"
         },
         "certifi": {
             "hashes": [
@@ -131,6 +131,13 @@
             "markers": "python_version != '3.4'",
             "version": "==0.4.3"
         },
+        "coloredlogs": {
+            "hashes": [
+                "sha256:346f58aad6afd48444c2468618623638dadab76e4e70d5e10822676f2d32226a",
+                "sha256:a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505"
+            ],
+            "version": "==14.0"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
@@ -204,6 +211,13 @@
                 "sha256:ef1d60b01b5ce0040ad3ec20bc64f783362d41fa0822a2742d3586e1f49bb8ac"
             ],
             "version": "==3.1.3"
+        },
+        "humanfriendly": {
+            "hashes": [
+                "sha256:bf52ec91244819c780341a3438d5d7b09f431d3f113a475147ac9b7b167a3d12",
+                "sha256:e78960b31198511f45fd455534ae7645a6207d33e512d2e842c766d15d9c8080"
+            ],
+            "version": "==8.2"
         },
         "idna": {
             "hashes": [
@@ -547,17 +561,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c2a223f4b48782e8b160b2130265e2a66081df111f630a5a384d6909e29a5aa9",
-                "sha256:ce5a4ab6af9e993d1864209cbbb6f4812f65fbc57ad6b95e5967d8bf38b1dcfb"
+                "sha256:ae57df1fbad7e29954a160d77cbf650d6562eb0d304c1206afa71d914e771a66",
+                "sha256:cbe618d61cb8f75cd9495ea36e69bad7c8984eb11f02ad247be4c9a2eb7eb647"
             ],
-            "version": "==1.14.16"
+            "version": "==1.14.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:99d995ef99cf77458a661f3fc64e0c3a4ce77ca30facfdf0472f44b2953dd856",
-                "sha256:fe0c4f7cd6b67eff3b7cb8dff6709a65d6fca10b7b7449a493b2036915e98b4c"
+                "sha256:5528c04c360019c24f2706ce82872c9ab767a8c581beffdfdaf006cce7499cac",
+                "sha256:d65b5574dad8c221344496352245828d9ffecaa0868199eb04ccd2eb2ff09133"
             ],
-            "version": "==1.17.16"
+            "version": "==1.17.17"
         },
         "certifi": {
             "hashes": [
@@ -615,39 +629,42 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
-                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
-                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
-                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
-                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
-                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
-                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
-                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
-                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
-                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
-                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
-                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
-                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
-                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
-                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
-                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
-                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
-                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
-                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
-                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
-                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
-                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
-                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
-                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
-                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
-                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
-                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
-                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
-                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
-                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
-                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
+                "sha256:0fc4e0d91350d6f43ef6a61f64a48e917637e1dcfcba4b4b7d543c628ef82c2d",
+                "sha256:10f2a618a6e75adf64329f828a6a5b40244c1c50f5ef4ce4109e904e69c71bd2",
+                "sha256:12eaccd86d9a373aea59869bc9cfa0ab6ba8b1477752110cb4c10d165474f703",
+                "sha256:1874bdc943654ba46d28f179c1846f5710eda3aeb265ff029e0ac2b52daae404",
+                "sha256:1dcebae667b73fd4aa69237e6afb39abc2f27520f2358590c1b13dd90e32abe7",
+                "sha256:1e58fca3d9ec1a423f1b7f2aa34af4f733cbfa9020c8fe39ca451b6071237405",
+                "sha256:214eb2110217f2636a9329bc766507ab71a3a06a8ea30cdeebb47c24dce5972d",
+                "sha256:25fe74b5b2f1b4abb11e103bb7984daca8f8292683957d0738cd692f6a7cc64c",
+                "sha256:32ecee61a43be509b91a526819717d5e5650e009a8d5eda8631a59c721d5f3b6",
+                "sha256:3740b796015b889e46c260ff18b84683fa2e30f0f75a171fb10d2bf9fb91fc70",
+                "sha256:3b2c34690f613525672697910894b60d15800ac7e779fbd0fccf532486c1ba40",
+                "sha256:41d88736c42f4a22c494c32cc48a05828236e37c991bd9760f8923415e3169e4",
+                "sha256:42fa45a29f1059eda4d3c7b509589cc0343cd6bbf083d6118216830cd1a51613",
+                "sha256:4bb385a747e6ae8a65290b3df60d6c8a692a5599dc66c9fa3520e667886f2e10",
+                "sha256:509294f3e76d3f26b35083973fbc952e01e1727656d979b11182f273f08aa80b",
+                "sha256:5c74c5b6045969b07c9fb36b665c9cac84d6c174a809fc1b21bdc06c7836d9a0",
+                "sha256:60a3d36297b65c7f78329b80120f72947140f45b5c7a017ea730f9112b40f2ec",
+                "sha256:6f91b4492c5cde83bfe462f5b2b997cdf96a138f7c58b1140f05de5751623cf1",
+                "sha256:7403675df5e27745571aba1c957c7da2dacb537c21e14007ec3a417bf31f7f3d",
+                "sha256:87bdc8135b8ee739840eee19b184804e5d57f518578ffc797f5afa2c3c297913",
+                "sha256:8a3decd12e7934d0254939e2bf434bf04a5890c5bf91a982685021786a08087e",
+                "sha256:9702e2cb1c6dec01fb8e1a64c015817c0800a6eca287552c47a5ee0ebddccf62",
+                "sha256:a4d511012beb967a39580ba7d2549edf1e6865a33e5fe51e4dce550522b3ac0e",
+                "sha256:bbb387811f7a18bdc61a2ea3d102be0c7e239b0db9c83be7bfa50f095db5b92a",
+                "sha256:bfcc811883699ed49afc58b1ed9f80428a18eb9166422bce3c31a53dba00fd1d",
+                "sha256:c32aa13cc3fe86b0f744dfe35a7f879ee33ac0a560684fef0f3e1580352b818f",
+                "sha256:ca63dae130a2e788f2b249200f01d7fa240f24da0596501d387a50e57aa7075e",
+                "sha256:d54d7ea74cc00482a2410d63bf10aa34ebe1c49ac50779652106c867f9986d6b",
+                "sha256:d67599521dff98ec8c34cd9652cbcfe16ed076a2209625fca9dc7419b6370e5c",
+                "sha256:d82db1b9a92cb5c67661ca6616bdca6ff931deceebb98eecbd328812dab52032",
+                "sha256:d9ad0a988ae20face62520785ec3595a5e64f35a21762a57d115dae0b8fb894a",
+                "sha256:ebf2431b2d457ae5217f3a1179533c456f3272ded16f8ed0b32961a6d90e38ee",
+                "sha256:ed9a21502e9223f563e071759f769c3d6a2e1ba5328c31e86830368e8d78bc9c",
+                "sha256:f50632ef2d749f541ca8e6c07c9928a37f87505ce3a9f20c8446ad310f1aa87b"
             ],
-            "version": "==5.1"
+            "version": "==5.2"
         },
         "cryptography": {
             "hashes": [

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -44,10 +44,10 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:30067e5e846b308b99ca87413b240589a3f063cee98257632798cc2282d280ce",
-                "sha256:7e0d026ff9e2c2628dc2cbbd42feea053205f55e316f76e79dd9e2018d78b577"
+                "sha256:ba5e5ba0eb86455f423a91c8e788a4818e9cc9fe19a690432089d1932f28119d",
+                "sha256:def6693c83bec66fab8ee72edcbaef0a6d3ec75094dae4f2699fd05df0f99aa7"
             ],
-            "version": "==1.18.93"
+            "version": "==1.18.97"
         },
         "babel": {
             "hashes": [
@@ -58,17 +58,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c2a223f4b48782e8b160b2130265e2a66081df111f630a5a384d6909e29a5aa9",
-                "sha256:ce5a4ab6af9e993d1864209cbbb6f4812f65fbc57ad6b95e5967d8bf38b1dcfb"
+                "sha256:e6ab26155b2f83798218106580ab2b3cd47691e25aba912e0351502eda8d86e0",
+                "sha256:f7aa33b382cc9e73ef7f590b885e72732ad2bd9628c5e312c9aeb8ba011c6820"
             ],
-            "version": "==1.14.16"
+            "version": "==1.14.20"
         },
         "botocore": {
             "hashes": [
-                "sha256:99d995ef99cf77458a661f3fc64e0c3a4ce77ca30facfdf0472f44b2953dd856",
-                "sha256:fe0c4f7cd6b67eff3b7cb8dff6709a65d6fca10b7b7449a493b2036915e98b4c"
+                "sha256:d1bf8c2085719221683edf54913c6155c68705f26ab4a72c45e4de5176a8cf7b",
+                "sha256:e7fee600092b51ca8016c541d5c50a8b39179d5c184ec3fd430400d99ba0c55a"
             ],
-            "version": "==1.17.16"
+            "version": "==1.17.20"
         },
         "certifi": {
             "hashes": [
@@ -145,6 +145,13 @@
             "markers": "python_version != '3.4'",
             "version": "==0.4.3"
         },
+        "coloredlogs": {
+            "hashes": [
+                "sha256:346f58aad6afd48444c2468618623638dadab76e4e70d5e10822676f2d32226a",
+                "sha256:a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505"
+            ],
+            "version": "==14.0"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
@@ -215,10 +222,17 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:e107af4d873daed64648b4f4beb89f89f0cfbe3ef558fc7821ed2331c2f8da1a",
-                "sha256:ef1d60b01b5ce0040ad3ec20bc64f783362d41fa0822a2742d3586e1f49bb8ac"
+                "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858",
+                "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"
             ],
-            "version": "==3.1.3"
+            "version": "==3.1.7"
+        },
+        "humanfriendly": {
+            "hashes": [
+                "sha256:bf52ec91244819c780341a3438d5d7b09f431d3f113a475147ac9b7b167a3d12",
+                "sha256:e78960b31198511f45fd455534ae7645a6207d33e512d2e842c766d15d9c8080"
+            ],
+            "version": "==8.2"
         },
         "idna": {
             "hashes": [
@@ -277,6 +291,14 @@
                 "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
             ],
             "version": "==3.2.0"
+        },
+        "jsx-lexer": {
+            "hashes": [
+                "sha256:1cb35102b78525aa3f587dc327f3208c0e1c76d5cdea64d4f9c3ced05d10c017",
+                "sha256:b879c7fafe974440a1dd9f9544dfb8629fa22078ada7f769c8fbb06149eac5d1"
+            ],
+            "index": "pypi",
+            "version": "==0.0.8"
         },
         "junit-xml": {
             "hashes": [
@@ -445,10 +467,11 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
-                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
+                "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
+                "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "version": "==3.4.2"
+            "markers": "python_version != '3.4'",
+            "version": "==4.5"
         },
         "runway": {
             "editable": true,
@@ -564,9 +587,9 @@
         },
         "troposphere": {
             "hashes": [
-                "sha256:a5423347ffbd431c397db02e90dffe3f0bcee199a3e67eae3a76ce5b6f758b7d"
+                "sha256:e6f0883022a660d4096264496db0bceb2655f0b032bddb908525f98ec0958647"
             ],
-            "version": "==2.6.1"
+            "version": "==2.6.2"
         },
         "urllib3": {
             "hashes": [

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,10 +3,10 @@ alabaster==0.7.12
 attrs==19.3.0
 awacs==0.9.8
 aws-sam-translator==1.25.0
-awscli==1.18.93
+awscli==1.18.97
 babel==2.8.0
-boto3==1.14.16
-botocore==1.17.16
+boto3==1.14.20
+botocore==1.17.20
 certifi==2020.6.20
 cffi==1.14.0
 cfn-flip==1.2.3
@@ -14,6 +14,7 @@ cfn-lint==0.33.2
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3 ; python_version != '3.4'
+coloredlogs==14.0
 cryptography==2.9.2
 decorator==4.4.2
 docker==4.2.2
@@ -21,7 +22,8 @@ docutils==0.15.2
 formic2==1.0.3
 future==0.18.2
 gitdb==4.0.5
-gitpython==3.1.3
+gitpython==3.1.7
+humanfriendly==8.2
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==1.7.0 ; python_version < '3.8'
@@ -30,6 +32,7 @@ jmespath==0.10.0
 jsonpatch==1.26 ; python_version != '3.4'
 jsonpointer==2.0
 jsonschema==3.2.0
+jsx-lexer==0.0.8
 junit-xml==1.9
 markupsafe==1.1.1
 more-itertools==8.4.0
@@ -48,7 +51,7 @@ python-dateutil==2.8.1
 pytz==2020.1
 pyyaml==5.2 ; python_version != '3.4'
 requests==2.24.0
-rsa==3.4.2
+rsa==4.5 ; python_version != '3.4'
 s3transfer==0.3.3
 schematics==2.0.1
 send2trash==1.5.0
@@ -64,7 +67,7 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-troposphere==2.6.1
+troposphere==2.6.2
 urllib3==1.24.3 ; python_version != '3.4'
 websocket-client==0.57.0
 yamllint==1.23.0

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -285,7 +285,7 @@ If a directory already exists with the name Runway tries to use, the sample will
 |                    | bucket & DDB table (perfect for storing Terraform_|
 |                    | backend state)                                    |
 +--------------------+---------------------------------------------------+
-| `cfngin`           | :ref:`Troposphere <mod-cfn>` identical to the     |
+| ``cfngin``         | :ref:`Troposphere <mod-cfn>` identical to the     |
 |                    | ``cfn`` sample but written in Python              |
 +--------------------+---------------------------------------------------+
 | ``k8s-cfn-repo``   | :ref:`mod-k8s` EKS cluster & sample app using     |

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -52,11 +52,13 @@ When this command is used, the following will take place:
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
   --tag <tag>...                  Select modules by tag or tags.
                                   This option can be specified more than once to
                                   build a list of tags that are treated as "AND".
                                   (e.g. "--tag <tag1> --tag <tag2>" would select
                                   all modules with BOTH tags).
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -116,11 +118,13 @@ When this command is used, the following will take place:
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
   --tag <tag>...                  Select modules by tag or tags.
                                   This option can be specified more than once to
                                   build a list of tags that are treated as "AND".
                                   (e.g. "--tag <tag1> --tag <tag2>" would select
                                   all modules with BOTH tags).
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -158,11 +162,13 @@ Alias of :ref:`command-destroy`.
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
   --tag <tag>...                  Select modules by tag or tags.
                                   This option can be specified more than once to
                                   build a list of tags that are treated as "AND".
                                   (e.g. "--tag <tag1> --tag <tag2>" would select
                                   all modules with BOTH tags).
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -203,6 +209,8 @@ This command allows access to these values for use outside of Runway.
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -237,6 +245,8 @@ Open the Runway documentation web site using the default web browser.
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -303,6 +313,15 @@ If a directory already exists with the name Runway tries to use, the sample will
   $ runway gen-sample [OPTIONS] <sample>
 
 
+.. rubric:: Options
+.. code-block:: text
+
+  --debug                         Supply once to display Runway debug logs.
+                                  Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
+
+
 .. rubric:: Example
 .. code-block:: shell
 
@@ -333,6 +352,8 @@ Creates a sample :ref:`runway-config` in the current directory.
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -371,6 +392,8 @@ Compatible with `alexppg/kbenv <https://github.com/alexppg/kbenv>`__.
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -407,6 +430,8 @@ Uses the version of kubectl_ specified in the ``.kubectl-version`` file in the c
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -463,11 +488,13 @@ When this command is used, the following will take place:
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
   --tag <tag>...                  Select modules by tag or tags.
                                   This option can be specified more than once to
                                   build a list of tags that are treated as "AND".
                                   (e.g. "--tag <tag1> --tag <tag2>" would select
                                   all modules with BOTH tags).
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -504,6 +531,8 @@ Alias of :ref:`command-test`.
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -540,6 +569,8 @@ This command gives access to the awscli when it might not otherwise be installed
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -577,6 +608,8 @@ When installed from PyPI, the current interpreter is used.
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -615,6 +648,8 @@ This command allows direct access to Runway's CloudFormation management tool.
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -651,11 +686,13 @@ Alias of :ref:`command-deploy`
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
   --tag <tag>...                  Select modules by tag or tags.
                                   This option can be specified more than once to
                                   build a list of tags that are treated as "AND".
                                   (e.g. "--tag <tag1> --tag <tag2>" would select
                                   all modules with BOTH tags).
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -693,11 +730,13 @@ Alias of :ref:`command-plan`.
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
   --tag <tag>...                  Select modules by tag or tags.
                                   This option can be specified more than once to
                                   build a list of tags that are treated as "AND".
                                   (e.g. "--tag <tag1> --tag <tag2>" would select
                                   all modules with BOTH tags).
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -738,6 +777,8 @@ If any tests fail, the command with exit with a non-zero exit code.
                                   Supply twice to display all debug logs.
   -e, --deploy-environment <env-name>
                                   Manually specify the name of the deploy environment.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -774,6 +815,8 @@ If this file doesn't exist, nothing will be installed.
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -810,6 +853,8 @@ Uses the version of Terraform_ specified in the ``.terraform-version`` file in t
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example
@@ -849,6 +894,8 @@ When run, the :ref:`deploy environment <term-deploy-env>`  will be determined fr
 
   --debug                         Supply once to display Runway debug logs.
                                   Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
 
 
 .. rubric:: Example

--- a/docs/source/developers/advanced_configuration.rst
+++ b/docs/source/developers/advanced_configuration.rst
@@ -12,10 +12,14 @@ Environment Variables
 Environment variables can be used to alter the functionality of Runway.
 
 **CI (Any)**
-  If not ``undefined``, Runway will operate in non-iterative mode,
+  If not ``undefined``, Runway will operate in non-iterative mode.
 
-**DEBUG (Any)**
-  If not ``undefined``, debug logs will be shown.
+**DEBUG (int)**
+  Used to select the debug logs to display
+
+  - ``0`` or not defined with show no debug logs
+  - ``1`` will show Runway's debug logs
+  - ``2`` will show Runway's debug logs and some dependency debug logs (e.g. botocore)
 
 **DEPLOY_ENVIRONMENT (str)**
   Explicitly define the deploy environment.
@@ -53,3 +57,31 @@ Environment variables can be used to alter the functionality of Runway.
   **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
   together, please consider the nature of their relationship when
   manually setting this value. (``parallel_regions * child_modules``)
+
+**RUNWAY_LOG_FIELD_STYLES (str)**
+  Can be provided to customize the styling (color, bold, etc) used for `LogRecord attributes`_ (except for message).
+  By default, Runway does not apply style to fields.
+  For information on how to format the value, see the documentation provided by coloredlogs_.
+
+**RUNWAY_LOG_FORMAT (str)**
+  Can be provided to use a custom log message format.
+  The value should be a format string using %-formatting.
+  In addition to being able to use `LogRecord attributes`_ in the string, Runway provides the additional fields of ``%(hostname)s`` and ``%(programname)s``.
+
+  If not provided, ``[%(programname)s] %(message)s`` is used unless using debug, verbose or no color.
+  In that case, ``%(levelname)s:%(name)s:%(message)s`` is used.
+
+**RUNWAY_LOG_LEVEL_STYLES (str)**
+  Can be provided to customize the styling (color, bold, etc) used for log messages sent to each log level.
+  If provided, the parsed value will be merged with Runway's default styling.
+  For information on how to format the value, see the documentation provided by coloredlogs_.
+
+**RUNWAY_NO_COLOR (Any)**
+  Disable Runway's colorized logs.
+  Providing this will also change the log format to ``%(levelname)s:%(name)s:%(message)s``.
+
+**VERBOSE (Any)**
+  If not ``undefined``, Runway will display verbose logs and change the logging format to ``%(levelname)s:%(name)s:%(message)s``.
+
+.. _LogRecord attributes: https://docs.python.org/3/library/logging.html#logrecord-attributes
+.. _coloredlogs: https://coloredlogs.readthedocs.io/en/latest/api.html#changing-the-colors-styles

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ Very simple configuration to:
 
 ----
 
+.. _module-configurations:
 
 ********************
 Module Configuration

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -120,6 +120,7 @@ config_ file.
 .. rubric:: Example
 
 .. code-block:: json
+
     {
         "stack1": [],
         "stack2": [

--- a/docs/source/terraform/configuration.rst
+++ b/docs/source/terraform/configuration.rst
@@ -71,7 +71,7 @@ runway.yml
 ==========
 
 Variable values can also be specified as parameter values in runway.yml. It
-is recommended to use `Lookups`_ in the ``parameters`` section to
+is recommended to use :ref:`Lookups` in the ``parameters`` section to
 assist in selecting the appropriate values for the deploy environment and/or
 region being deployed to but, this is not a requirement if the value will
 remain the same.

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -39,24 +39,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:30067e5e846b308b99ca87413b240589a3f063cee98257632798cc2282d280ce",
-                "sha256:7e0d026ff9e2c2628dc2cbbd42feea053205f55e316f76e79dd9e2018d78b577"
+                "sha256:ba5e5ba0eb86455f423a91c8e788a4818e9cc9fe19a690432089d1932f28119d",
+                "sha256:def6693c83bec66fab8ee72edcbaef0a6d3ec75094dae4f2699fd05df0f99aa7"
             ],
-            "version": "==1.18.93"
+            "version": "==1.18.97"
         },
         "boto3": {
             "hashes": [
-                "sha256:c2a223f4b48782e8b160b2130265e2a66081df111f630a5a384d6909e29a5aa9",
-                "sha256:ce5a4ab6af9e993d1864209cbbb6f4812f65fbc57ad6b95e5967d8bf38b1dcfb"
+                "sha256:e6ab26155b2f83798218106580ab2b3cd47691e25aba912e0351502eda8d86e0",
+                "sha256:f7aa33b382cc9e73ef7f590b885e72732ad2bd9628c5e312c9aeb8ba011c6820"
             ],
-            "version": "==1.14.16"
+            "version": "==1.14.20"
         },
         "botocore": {
             "hashes": [
-                "sha256:99d995ef99cf77458a661f3fc64e0c3a4ce77ca30facfdf0472f44b2953dd856",
-                "sha256:fe0c4f7cd6b67eff3b7cb8dff6709a65d6fca10b7b7449a493b2036915e98b4c"
+                "sha256:d1bf8c2085719221683edf54913c6155c68705f26ab4a72c45e4de5176a8cf7b",
+                "sha256:e7fee600092b51ca8016c541d5c50a8b39179d5c184ec3fd430400d99ba0c55a"
             ],
-            "version": "==1.17.16"
+            "version": "==1.17.20"
         },
         "certifi": {
             "hashes": [
@@ -133,6 +133,13 @@
             "index": "pypi",
             "version": "==0.3.9"
         },
+        "coloredlogs": {
+            "hashes": [
+                "sha256:346f58aad6afd48444c2468618623638dadab76e4e70d5e10822676f2d32226a",
+                "sha256:a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505"
+            ],
+            "version": "==14.0"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
@@ -202,10 +209,17 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:e107af4d873daed64648b4f4beb89f89f0cfbe3ef558fc7821ed2331c2f8da1a",
-                "sha256:ef1d60b01b5ce0040ad3ec20bc64f783362d41fa0822a2742d3586e1f49bb8ac"
+                "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858",
+                "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"
             ],
-            "version": "==3.1.3"
+            "version": "==3.1.7"
+        },
+        "humanfriendly": {
+            "hashes": [
+                "sha256:bf52ec91244819c780341a3438d5d7b09f431d3f113a475147ac9b7b167a3d12",
+                "sha256:e78960b31198511f45fd455534ae7645a6207d33e512d2e842c766d15d9c8080"
+            ],
+            "version": "==8.2"
         },
         "idna": {
             "hashes": [
@@ -414,10 +428,11 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
-                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
+                "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
+                "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "version": "==3.4.2"
+            "markers": "python_version != '3.4'",
+            "version": "==4.5"
         },
         "runway": {
             "editable": true,
@@ -460,9 +475,9 @@
         },
         "troposphere": {
             "hashes": [
-                "sha256:a5423347ffbd431c397db02e90dffe3f0bcee199a3e67eae3a76ce5b6f758b7d"
+                "sha256:e6f0883022a660d4096264496db0bceb2655f0b032bddb908525f98ec0958647"
             ],
-            "version": "==2.6.1"
+            "version": "==2.6.2"
         },
         "urllib3": {
             "hashes": [

--- a/integration_tests/test_cfngin/tests/02_no_stacks_in_config.py
+++ b/integration_tests/test_cfngin/tests/02_no_stacks_in_config.py
@@ -21,7 +21,7 @@ class TestNoStacksInConfig(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'WARNING: No stacks detected (error in config?)'
+            'no stacks detected (error in config?)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'

--- a/integration_tests/test_cfngin/tests/06_missing_variable.py
+++ b/integration_tests/test_cfngin/tests/06_missing_variable.py
@@ -27,7 +27,7 @@ class TestMissingVariable(Cfngin):
         assert code != 0, 'exit code should be non-zero'
         expected_lines = [
             'MissingVariable: Variable "PrivateSubnets" in blueprint "vpc" is missing',
-            'vpc: failed (Variable "PrivateSubnets" in blueprint "vpc" is missing)'
+            'vpc:failed (Variable "PrivateSubnets" in blueprint "vpc" is missing)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'

--- a/integration_tests/test_cfngin/tests/07_simple_build.py
+++ b/integration_tests/test_cfngin/tests/07_simple_build.py
@@ -25,9 +25,9 @@ class TestSimpleBuild(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'Using default AWS provider mode',
-            'simple-build-vpc: submitted (creating new stack)',
-            'simple-build-vpc: complete (creating new stack)'
+            'using default AWS provider mode',
+            'simple-build-vpc:submitted (creating new stack)',
+            'simple-build-vpc:complete (creating new stack)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'
@@ -37,8 +37,8 @@ class TestSimpleBuild(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'Using default AWS provider mode',
-            'simple-build-vpc: skipped (nochange)'
+            'using default AWS provider mode',
+            'simple-build-vpc:skipped (nochange)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'
@@ -48,8 +48,8 @@ class TestSimpleBuild(Cfngin):
         code, _stdout, stderr = self.runway_cmd('destroy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'simple-build-vpc: submitted (submitted for destruction)',
-            'simple-build-vpc: complete (stack destroyed)'
+            'simple-build-vpc:submitted (submitted for destruction)',
+            'simple-build-vpc:complete (stack destroyed)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'
@@ -57,11 +57,13 @@ class TestSimpleBuild(Cfngin):
     def run(self):
         """Run the test."""
         self.copy_fixtures()
+        self.set_env_var('VERBOSE', '1')
         self._build()
         self._update_no_change()
         self._destroy()
 
     def teardown(self):
         """Teardown any created resources and delete files."""
+        self.unset_env_var('VERBOSE')
         self.runway_cmd('destroy')  # cleanup incase of failure
         self.cleanup_fixtures()

--- a/integration_tests/test_cfngin/tests/10_locked_stack.py
+++ b/integration_tests/test_cfngin/tests/10_locked_stack.py
@@ -27,12 +27,11 @@ class TestLockedStack(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'Using default AWS provider mode',
-            'locked-stack-vpc: submitted (creating new stack)',
-            'locked-stack-vpc: complete (creating new stack)',
-            'locked-stack-vpc: skipped (locked)',
-            'locked-stack-bastion: submitted (creating new stack)',
-            'locked-stack-bastion: complete (creating new stack)'
+            'locked-stack-vpc:submitted (creating new stack)',
+            'locked-stack-vpc:complete (creating new stack)',
+            'locked-stack-vpc:skipped (locked)',
+            'locked-stack-bastion:submitted (creating new stack)',
+            'locked-stack-bastion:complete (creating new stack)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'

--- a/integration_tests/test_cfngin/tests/11_recreate_failed.py
+++ b/integration_tests/test_cfngin/tests/11_recreate_failed.py
@@ -30,9 +30,8 @@ class TestRecreateFailed(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code != 0, 'exit code should be non-zero since one config failed'
         expected_lines = [
-            'recreate-failed: submitted (creating new stack)',
-            'recreate-failed: submitted (rolling back new stack)',
-            # 'recreate-failed: failed (rolled back new stack)',
+            'recreate-failed:submitted (creating new stack)',
+            'recreate-failed:submitted (rolling back new stack)',
             'The following steps failed: recreate-failed'
         ]
         for line in expected_lines:
@@ -45,9 +44,9 @@ class TestRecreateFailed(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'recreate-failed: submitted (destroying stack for re-creation)',
-            'recreate-failed: submitted (creating new stack)',
-            'recreate-failed: complete (creating new stack)'
+            'recreate-failed:submitted (destroying stack for re-creation)',
+            'recreate-failed:submitted (creating new stack)',
+            'recreate-failed:complete (creating new stack)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'

--- a/integration_tests/test_cfngin/tests/12_rollback_dependent.py
+++ b/integration_tests/test_cfngin/tests/12_rollback_dependent.py
@@ -27,11 +27,11 @@ class TestRollbackWithDependent(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code != 0, 'exit code should be non-zero'
         expected_lines = [
-            'dependent-rollback-parent: submitted (creating new stack)',
+            'dependent-rollback-parent:submitted (creating new stack)',
             # the suffix of the below log message can very based on when
             # CFN is polled b/c of how fast the test stack is
-            'dependent-rollback-parent: failed',
-            'dependent-rollback-child: failed (dependency has failed)',
+            'dependent-rollback-parent:failed',
+            'dependent-rollback-child:failed (dependency has failed)',
             'The following steps failed: dependent-rollback-parent, dependent-rollback-child'
         ]
         for line in expected_lines:

--- a/integration_tests/test_cfngin/tests/13_raw_template.py
+++ b/integration_tests/test_cfngin/tests/13_raw_template.py
@@ -23,9 +23,8 @@ class TestRawTemplate(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'Using default AWS provider mode',
-            'raw-template-vpc: submitted (creating new stack)',
-            'raw-template-vpc: complete (creating new stack)'
+            'raw-template-vpc:submitted (creating new stack)',
+            'raw-template-vpc:complete (creating new stack)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'
@@ -35,8 +34,7 @@ class TestRawTemplate(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'Using default AWS provider mode',
-            'raw-template-vpc: skipped (nochange)'
+            'raw-template-vpc:skipped (nochange)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'
@@ -46,8 +44,8 @@ class TestRawTemplate(Cfngin):
         code, _stdout, stderr = self.runway_cmd('destroy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'raw-template-vpc: submitted (submitted for destruction)',
-            'raw-template-vpc: complete (stack destroyed)'
+            'raw-template-vpc:submitted (submitted for destruction)',
+            'raw-template-vpc:complete (stack destroyed)'
         ]
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'

--- a/integration_tests/test_cfngin/tests/15_destroy_removed.py
+++ b/integration_tests/test_cfngin/tests/15_destroy_removed.py
@@ -24,15 +24,15 @@ class DestroyRemoved(Cfngin):
         code, _stdout, stderr = self.runway_cmd('deploy')
         assert code == 0, 'exit code should be zero'
         expected_lines = [
-            'other was removed from the Stacker config file so it is being destroyed.',
-            'other: submitted (submitted for destruction)',
-            'other: complete (stack destroyed)'
+            'other:removed from the CFNgin config file; it is being destroyed',
+            'other:submitted (submitted for destruction)',
+            'other:complete (stack destroyed)'
         ]
         for stack in ['vpc', 'bastion', 'other']:
-            expected_lines.append(f'{stack}: submitted (creating new stack)')
-            expected_lines.append(f'{stack}: complete (creating new stack)')
+            expected_lines.append(f'{stack}:submitted (creating new stack)')
+            expected_lines.append(f'{stack}:complete (creating new stack)')
             if stack != 'other':
-                expected_lines.append(f'{stack}: skipped (nochange)')
+                expected_lines.append(f'{stack}:skipped (nochange)')
         for line in expected_lines:
             assert line in stderr, f'"{line}" missing from output'
 

--- a/runway/__init__.py
+++ b/runway/__init__.py
@@ -1,17 +1,20 @@
 """Set package version."""
+# pylint: disable=wrong-import-position
 import logging
 import sys
 
-from . import cfngin, variables
-from ._logging import LogLevels, RunwayLogger  # noqa
+from ._logging import LogLevels, RunwayLogger  # noqa  isort:skip
+
+logging.setLoggerClass(RunwayLogger)  # isort:skip
+
+# these need to be imported after setting the logger class
+from . import cfngin, variables  # noqa isort:skip
 
 if sys.version_info.minor < 8:
     # importlib.metadata is standard lib for python>=3.8, use backport
     from importlib_metadata import version, PackageNotFoundError
 else:
     from importlib.metadata import version, PackageNotFoundError  # pylint: disable=E
-
-logging.setLoggerClass(RunwayLogger)
 
 sys.modules['stacker'] = cfngin  # shim to remove stacker dependency
 sys.modules['stacker.variables'] = variables  # shim to support standard variables

--- a/runway/__init__.py
+++ b/runway/__init__.py
@@ -1,13 +1,17 @@
 """Set package version."""
+import logging
 import sys
 
 from . import cfngin, variables
+from ._logging import LogLevels, RunwayLogger  # noqa
 
 if sys.version_info.minor < 8:
     # importlib.metadata is standard lib for python>=3.8, use backport
     from importlib_metadata import version, PackageNotFoundError
 else:
     from importlib.metadata import version, PackageNotFoundError  # pylint: disable=E
+
+logging.setLoggerClass(RunwayLogger)
 
 sys.modules['stacker'] = cfngin  # shim to remove stacker dependency
 sys.modules['stacker.variables'] = variables  # shim to support standard variables

--- a/runway/_cli/commands/_deploy.py
+++ b/runway/_cli/commands/_deploy.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.ci
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.tags
 @options.verbose
 @click.pass_context

--- a/runway/_cli/commands/_deploy.py
+++ b/runway/_cli/commands/_deploy.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.deploy_environment
 @options.tags
+@options.verbose
 @click.pass_context
 def deploy(ctx, tags, **_):  # noqa: D301
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_destroy.py
+++ b/runway/_cli/commands/_destroy.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.deploy_environment
 @options.tags
+@options.verbose
 @click.pass_context
 def destroy(ctx, tags, **_):  # noqa: D301
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_destroy.py
+++ b/runway/_cli/commands/_destroy.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.ci
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.tags
 @options.verbose
 @click.pass_context

--- a/runway/_cli/commands/_dismantle.py
+++ b/runway/_cli/commands/_dismantle.py
@@ -21,5 +21,5 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 def dismantle(ctx, **kwargs):
     # type: (click.Context, Tuple[str, ...], Any) -> None
     """Alias of "runway destroy"."""
-    LOGGER.debug('forwarding to destroy...')
+    LOGGER.verbose('forwarding to destroy...')
     ctx.forward(destroy, **kwargs)

--- a/runway/_cli/commands/_dismantle.py
+++ b/runway/_cli/commands/_dismantle.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.ci
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.tags
 @options.verbose
 @click.pass_context

--- a/runway/_cli/commands/_dismantle.py
+++ b/runway/_cli/commands/_dismantle.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.deploy_environment
 @options.tags
+@options.verbose
 @click.pass_context
 def dismantle(ctx, **kwargs):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_docs.py
+++ b/runway/_cli/commands/_docs.py
@@ -16,6 +16,7 @@ DOCS_URL = 'https://docs.onica.com/projects/runway/'
 
 @click.command('docs', short_help='open doc site')
 @options.debug
+@options.verbose
 def docs(**_):
     # type: (Any) -> None
     """Open the Runway documentation web site using the default web browser."""

--- a/runway/_cli/commands/_docs.py
+++ b/runway/_cli/commands/_docs.py
@@ -16,6 +16,7 @@ DOCS_URL = 'https://docs.onica.com/projects/runway/'
 
 @click.command('docs', short_help='open doc site')
 @options.debug
+@options.no_color
 @options.verbose
 def docs(**_):
     # type: (Any) -> None

--- a/runway/_cli/commands/_docs.py
+++ b/runway/_cli/commands/_docs.py
@@ -34,5 +34,5 @@ def docs(**_):
             # Remove the env var as a last resort:
             LOGGER.debug('temporarily removing environ: %s', lp_key)
             os.environ.pop(lp_key, None)
-        LOGGER.debug('launching url: %s', DOCS_URL)
+        LOGGER.verbose('launching url: %s', DOCS_URL)
         click.launch(DOCS_URL)

--- a/runway/_cli/commands/_envvars.py
+++ b/runway/_cli/commands/_envvars.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('envvars', short_help='exportable env_vars')
 @options.debug
 @options.deploy_environment
+@options.verbose
 @click.pass_context
 def envvars(ctx, **_):
     """Output env_vars defined in the Runway config file.

--- a/runway/_cli/commands/_envvars.py
+++ b/runway/_cli/commands/_envvars.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('envvars', short_help='exportable env_vars')
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.verbose
 @click.pass_context
 def envvars(ctx, **_):

--- a/runway/_cli/commands/_envvars.py
+++ b/runway/_cli/commands/_envvars.py
@@ -28,16 +28,18 @@ def envvars(ctx, **_):
     NOTE: Only outputs env_vars defined in deployments, not modules.
 
     """
-    if not ctx.obj.debug:
+    if not (ctx.obj.debug or ctx.obj.verbose):
         logging.getLogger('runway').setLevel(logging.ERROR)  # suppress warnings
-    ctx.obj.env.ci = True  # suppress any prompts
+
+    ctx.obj.env.ci = True
+    LOGGER.verbose('forced Runway to non-interactive mode to suppress prompts')
     env_vars = Runway(ctx.obj.runway_config,
                       ctx.obj.get_runway_context()).get_env_vars()
 
     if not env_vars:
         LOGGER.error('No env_vars defined in %s', ctx.obj.runway_config_path)
         ctx.exit(1)
-    LOGGER.debug('printing env_vars: %s', env_vars)
+    LOGGER.debug('env_vars: %s', env_vars)
     print_env_vars(env_vars)
 
 

--- a/runway/_cli/commands/_gen_sample/__init__.py
+++ b/runway/_cli/commands/_gen_sample/__init__.py
@@ -53,7 +53,7 @@ COMMANDS = [
 @click.group('gen-sample', short_help='generate sample module/project')
 @options.debug
 @options.verbose
-def gen_sample():
+def gen_sample(**_):
     """Generate a sample Runway module module/project.
 
     The sample is created in the current directory.

--- a/runway/_cli/commands/_gen_sample/__init__.py
+++ b/runway/_cli/commands/_gen_sample/__init__.py
@@ -52,6 +52,7 @@ COMMANDS = [
 
 @click.group('gen-sample', short_help='generate sample module/project')
 @options.debug
+@options.no_color
 @options.verbose
 def gen_sample(**_):
     """Generate a sample Runway module module/project.

--- a/runway/_cli/commands/_gen_sample/__init__.py
+++ b/runway/_cli/commands/_gen_sample/__init__.py
@@ -2,6 +2,7 @@
 # docs: file://./../../../../docs/source/commands.rst
 import click
 
+from ... import options
 from ._cdk_csharp import cdk_csharp
 from ._cdk_py import cdk_py
 from ._cdk_tsc import cdk_tsc
@@ -50,6 +51,8 @@ COMMANDS = [
 
 
 @click.group('gen-sample', short_help='generate sample module/project')
+@options.debug
+@options.verbose
 def gen_sample():
     """Generate a sample Runway module module/project.
 

--- a/runway/_cli/commands/_gen_sample/_cdk_csharp.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_csharp.py
@@ -28,6 +28,6 @@ def cdk_csharp(ctx):
     copy_sample(ctx, src, dest)
     convert_gitignore(dest / 'dot_gitignore')
 
-    LOGGER.info("Sample C# CDK module created at %s", dest)
-    LOGGER.info('To finish it\'s setup, change to the %s directory and execute'
-                ' "npm install" to generate it\'s lockfile.', dest)
+    LOGGER.success("Sample C# CDK module created at %s", dest)
+    LOGGER.notice('To finish it\'s setup, change to the %s directory and execute'
+                  ' "npm install" to generate it\'s lockfile.', dest)

--- a/runway/_cli/commands/_gen_sample/_cdk_csharp.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_csharp.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('cdk-csharp', short_help='cdk + c# (sampleapp.cdk)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def cdk_csharp(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_cdk_csharp.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_csharp.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def cdk_csharp(ctx):
+def cdk_csharp(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample AWS CDK project using C#."""
     src = TEMPLATES / 'cdk-csharp'

--- a/runway/_cli/commands/_gen_sample/_cdk_csharp.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_csharp.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, convert_gitignore, copy_sample
 
 if sys.version_info.major > 2:
@@ -15,6 +16,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('cdk-csharp', short_help='cdk + c# (sampleapp.cdk)')
+@options.debug
+@options.verbose
 @click.pass_context
 def cdk_csharp(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_cdk_py.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_py.py
@@ -27,6 +27,6 @@ def cdk_py(ctx):
     copy_sample(ctx, src, dest)
     # .gitignore already exists
 
-    LOGGER.info("Sample CDK module created at %s", dest)
-    LOGGER.info('To finish it\'s setup, change to the %s directory and execute'
-                ' "npm install" to generate it\'s lockfile.', dest)
+    LOGGER.success("Sample CDK module created at %s", dest)
+    LOGGER.notice('To finish it\'s setup, change to the %s directory and '
+                  'execute "npm install" to generate it\'s lockfile.', dest)

--- a/runway/_cli/commands/_gen_sample/_cdk_py.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_py.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def cdk_py(ctx):
+def cdk_py(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample AWS CDK project using python."""
     src = TEMPLATES / 'cdk-py'

--- a/runway/_cli/commands/_gen_sample/_cdk_py.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_py.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('cdk-py', short_help='cdk + py (sampleapp.cdk)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def cdk_py(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_cdk_py.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_py.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, copy_sample
 
 if sys.version_info.major > 2:
@@ -15,6 +16,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('cdk-py', short_help='cdk + py (sampleapp.cdk)')
+@options.debug
+@options.verbose
 @click.pass_context
 def cdk_py(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_cdk_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_tsc.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, copy_sample
 
 if sys.version_info.major > 2:
@@ -15,6 +16,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('cdk-tsc', short_help='cdk + tsc (sampleapp.cdk)')
+@options.debug
+@options.verbose
 @click.pass_context
 def cdk_tsc(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_cdk_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_tsc.py
@@ -27,6 +27,6 @@ def cdk_tsc(ctx):
     copy_sample(ctx, src, dest)
     # .gitignore already exists
 
-    LOGGER.info("Sample CDK module created at %s", dest)
-    LOGGER.info('To finish it\'s setup, change to the %s directory and execute'
-                ' "npm install" to generate it\'s lockfile.', dest)
+    LOGGER.success("Sample CDK module created at %s", dest)
+    LOGGER.notice('To finish it\'s setup, change to the %s directory and '
+                  'execute "npm install" to generate it\'s lockfile.', dest)

--- a/runway/_cli/commands/_gen_sample/_cdk_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_tsc.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('cdk-tsc', short_help='cdk + tsc (sampleapp.cdk)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def cdk_tsc(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_cdk_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_cdk_tsc.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def cdk_tsc(ctx):
+def cdk_tsc(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample AWS CDK project using TypeScript."""
     src = TEMPLATES / 'cdk-tsc'

--- a/runway/_cli/commands/_gen_sample/_cfn.py
+++ b/runway/_cli/commands/_gen_sample/_cfn.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('cfn',
                short_help="cfngin + cfn (sampleapp.cfn)")
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def cfn(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_cfn.py
+++ b/runway/_cli/commands/_gen_sample/_cfn.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def cfn(ctx):
+def cfn(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample CFNgin project using CloudFormation."""
     src = TEMPLATES / 'cfn'

--- a/runway/_cli/commands/_gen_sample/_cfn.py
+++ b/runway/_cli/commands/_gen_sample/_cfn.py
@@ -31,4 +31,4 @@ def cfn(ctx):
     copy_sample(ctx, src, dest)
     templates.mkdir()
     write_tfstate_template(tf_state)
-    LOGGER.info("Sample CloudFormation module created at %s", dest)
+    LOGGER.success("Sample CloudFormation module created at %s", dest)

--- a/runway/_cli/commands/_gen_sample/_cfn.py
+++ b/runway/_cli/commands/_gen_sample/_cfn.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, copy_sample, write_tfstate_template
 
 if sys.version_info.major > 2:
@@ -16,6 +17,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('cfn',
                short_help="cfngin + cfn (sampleapp.cfn)")
+@options.debug
+@options.verbose
 @click.pass_context
 def cfn(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_cfngin.py
+++ b/runway/_cli/commands/_gen_sample/_cfngin.py
@@ -39,5 +39,5 @@ def cfngin(ctx):
                     str(blueprints / '__init__.py'))
     shutil.copyfile(str(src_blueprints / 'tf_state.py'), str(tf_state))
     tf_state.chmod(tf_state.stat().st_mode | 0o0111)
-    LOGGER.info("Sample CFNgin module created at %s",
-                dest)
+    LOGGER.success("Sample CFNgin module created at %s",
+                   dest)

--- a/runway/_cli/commands/_gen_sample/_cfngin.py
+++ b/runway/_cli/commands/_gen_sample/_cfngin.py
@@ -5,6 +5,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import ROOT, TEMPLATES, copy_sample
 
 if sys.version_info.major > 2:
@@ -17,6 +18,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('cfngin',
                short_help="cfngin + troposphere (sampleapp.cfn)")
+@options.debug
+@options.verbose
 @click.pass_context
 def cfngin(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_cfngin.py
+++ b/runway/_cli/commands/_gen_sample/_cfngin.py
@@ -19,6 +19,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('cfngin',
                short_help="cfngin + troposphere (sampleapp.cfn)")
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def cfngin(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_cfngin.py
+++ b/runway/_cli/commands/_gen_sample/_cfngin.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def cfngin(ctx):
+def cfngin(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample CFNgin project using Blueprints."""
     src = TEMPLATES / 'cfngin'

--- a/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def k8s_cfn_repo(ctx):
+def k8s_cfn_repo(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample CloudFormation project using Kubernetes."""
     src = TEMPLATES / 'k8s-cfn-repo'

--- a/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
@@ -10,6 +10,7 @@ from ....blueprints.k8s.k8s_iam import Iam
 from ....blueprints.k8s.k8s_master import Cluster
 from ....blueprints.k8s.k8s_workers import NodeGroup
 from ....cfngin.context import Context as CFNginContext
+from ... import options
 from .utils import TEMPLATES, convert_gitignore, copy_sample
 
 if sys.version_info.major > 2:
@@ -22,6 +23,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('k8s-cfn-repo',
                short_help='k8s + cfn (k8s-cfn-infrastructure)')
+@options.debug
+@options.verbose
 @click.pass_context
 def k8s_cfn_repo(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
@@ -39,7 +39,7 @@ def k8s_cfn_repo(ctx):
     worker_templates = dest / 'k8s-workers.cfn/templates'
     env = {'namespace': 'test'}
 
-    LOGGER.debug('rendering master templates...')
+    LOGGER.verbose('rendering master templates...')
     master_templates.mkdir()
     (master_templates / 'k8s_iam.yaml').write_text(six.u(
         to_yaml(Iam('test', CFNginContext(env.copy()), None).to_json())
@@ -48,11 +48,11 @@ def k8s_cfn_repo(ctx):
         to_yaml(Cluster('test', CFNginContext(env.copy()), None).to_json())
     ))
 
-    LOGGER.debug('rendering worker templates...')
+    LOGGER.verbose('rendering worker templates...')
     worker_templates.mkdir()
     (worker_templates / 'k8s_workers.yaml').write_text(six.u(
         to_yaml(NodeGroup('test', CFNginContext(env.copy()), None).to_json())
     ))
 
-    LOGGER.info("Sample k8s infrastructure repo created at %s", dest)
-    LOGGER.info('(see its README for setup and deployment instructions)')
+    LOGGER.success("Sample k8s infrastructure repo created at %s", dest)
+    LOGGER.notice('See the README for setup and deployment instructions.')

--- a/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
@@ -24,6 +24,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('k8s-cfn-repo',
                short_help='k8s + cfn (k8s-cfn-infrastructure)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def k8s_cfn_repo(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
@@ -20,6 +20,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('k8s-tf-repo',
                short_help='k8s + tf (k8s-tf-infrastructure)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def k8s_tf_repo(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def k8s_tf_repo(ctx):
+def k8s_tf_repo(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample Terraform project using Kubernetes."""
     src = TEMPLATES / 'k8s-tf-repo'

--- a/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
@@ -39,5 +39,5 @@ def k8s_tf_repo(ctx):
     tfstate_dir.mkdir()
     write_tfstate_template(tfstate_dir / 'tf_state.yml')
 
-    LOGGER.info("Sample k8s infrastructure repo created at %s", dest)
-    LOGGER.info('(see its README for setup and deployment instructions)')
+    LOGGER.success("Sample k8s infrastructure repo created at %s", dest)
+    LOGGER.notice('See the README for setup and deployment instructions.')

--- a/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_tf_repo.py
@@ -5,6 +5,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import (TEMPLATES, convert_gitignore, copy_sample,
                     write_tfstate_template)
 
@@ -18,6 +19,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('k8s-tf-repo',
                short_help='k8s + tf (k8s-tf-infrastructure)')
+@options.debug
+@options.verbose
 @click.pass_context
 def k8s_tf_repo(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_sls_py.py
+++ b/runway/_cli/commands/_gen_sample/_sls_py.py
@@ -28,6 +28,6 @@ def sls_py(ctx):
     copy_sample(ctx, src, dest)
     convert_gitignore(dest / '_gitignore')
 
-    LOGGER.info("Sample Serverless module created at %s", dest)
-    LOGGER.info('To finish it\'s setup, change to the %s directory and execute'
-                ' "npm install" to generate it\'s lockfile.', dest)
+    LOGGER.success("Sample Serverless module created at %s", dest)
+    LOGGER.notice('To finish it\'s setup, change to the %s directory and '
+                  'execute "npm install" to generate it\'s lockfile.', dest)

--- a/runway/_cli/commands/_gen_sample/_sls_py.py
+++ b/runway/_cli/commands/_gen_sample/_sls_py.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('sls-py', short_help='sls + python (sampleapp.sls)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def sls_py(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_sls_py.py
+++ b/runway/_cli/commands/_gen_sample/_sls_py.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, convert_gitignore, copy_sample
 
 if sys.version_info.major > 2:
@@ -15,6 +16,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('sls-py', short_help='sls + python (sampleapp.sls)')
+@options.debug
+@options.verbose
 @click.pass_context
 def sls_py(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_sls_py.py
+++ b/runway/_cli/commands/_gen_sample/_sls_py.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def sls_py(ctx):
+def sls_py(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample Serverless project using python."""
     src = TEMPLATES / 'sls-py'

--- a/runway/_cli/commands/_gen_sample/_sls_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_sls_tsc.py
@@ -27,6 +27,6 @@ def sls_tsc(ctx):
     copy_sample(ctx, src, dest)
     convert_gitignore(dest / '_gitignore')
 
-    LOGGER.info("Sample Serverless module created at %s", dest)
-    LOGGER.info('To finish it\'s setup, change to the %s directory and execute'
-                ' "npm install" to generate it\'s lockfile.', dest)
+    LOGGER.success("Sample Serverless module created at %s", dest)
+    LOGGER.notice('To finish it\'s setup, change to the %s directory and '
+                  'execute "npm install" to generate it\'s lockfile.', dest)

--- a/runway/_cli/commands/_gen_sample/_sls_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_sls_tsc.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def sls_tsc(ctx):
+def sls_tsc(ctx, **_):
     """Generate a sample Serverless project using TypeScript."""
     src = TEMPLATES / 'sls-tsc'
     dest = Path.cwd() / 'sampleapp.sls'

--- a/runway/_cli/commands/_gen_sample/_sls_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_sls_tsc.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, convert_gitignore, copy_sample
 
 if sys.version_info.major > 2:
@@ -15,6 +16,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('sls-tsc', short_help='sls + tsc (sampleapp.sls)')
+@options.debug
+@options.verbose
 @click.pass_context
 def sls_tsc(ctx):
     """Generate a sample Serverless project using TypeScript."""

--- a/runway/_cli/commands/_gen_sample/_sls_tsc.py
+++ b/runway/_cli/commands/_gen_sample/_sls_tsc.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('sls-tsc', short_help='sls + tsc (sampleapp.sls)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def sls_tsc(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_stacker.py
+++ b/runway/_cli/commands/_gen_sample/_stacker.py
@@ -3,12 +3,15 @@ import logging
 
 import click
 
+from ... import options
 from ._cfngin import cfngin
 
 LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('stacker', short_help='deprecated, use cfngin')
+@options.debug
+@options.verbose
 @click.pass_context
 def stacker(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_stacker.py
+++ b/runway/_cli/commands/_gen_sample/_stacker.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('stacker', short_help='deprecated, use cfngin')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def stacker(ctx, **kwargs):

--- a/runway/_cli/commands/_gen_sample/_stacker.py
+++ b/runway/_cli/commands/_gen_sample/_stacker.py
@@ -13,10 +13,10 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def stacker(ctx):
+def stacker(ctx, **kwargs):
     # type: (click.Context) -> None
     """[DEPRECATED] Generate a sample CFNgin project using Blueprints."""
     LOGGER.warning('This command has been deprecated and will be removed in '
                    'the next major release.')
     LOGGER.verbose('forwarding to cfngin...')
-    ctx.forward(cfngin)
+    ctx.forward(cfngin, **kwargs)

--- a/runway/_cli/commands/_gen_sample/_stacker.py
+++ b/runway/_cli/commands/_gen_sample/_stacker.py
@@ -18,5 +18,5 @@ def stacker(ctx):
     """[DEPRECATED] Generate a sample CFNgin project using Blueprints."""
     LOGGER.warning('This command has been deprecated and will be removed in '
                    'the next major release.')
-    LOGGER.debug('forwarding to cfngin...')
+    LOGGER.verbose('forwarding to cfngin...')
     ctx.forward(cfngin)

--- a/runway/_cli/commands/_gen_sample/_static_angular.py
+++ b/runway/_cli/commands/_gen_sample/_static_angular.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, convert_gitignore, copy_sample
 
 if sys.version_info.major > 2:
@@ -16,6 +17,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('static-angular',
                short_help='angular static site (static-angular)')
+@options.debug
+@options.verbose
 @click.pass_context
 def static_angular(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_static_angular.py
+++ b/runway/_cli/commands/_gen_sample/_static_angular.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def static_angular(ctx):
+def static_angular(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample static site project using Angular."""
     src = TEMPLATES / 'static-angular'

--- a/runway/_cli/commands/_gen_sample/_static_angular.py
+++ b/runway/_cli/commands/_gen_sample/_static_angular.py
@@ -29,5 +29,5 @@ def static_angular(ctx):
     copy_sample(ctx, src, dest)
     convert_gitignore(dest / 'sampleapp.web/_gitignore')
 
-    LOGGER.info("Sample static Angular site repo created at %s", dest)
-    LOGGER.info('(see its README for setup and deployment instructions)')
+    LOGGER.success("Sample static Angular site repo created at %s", dest)
+    LOGGER.notice('See the README for setup and deployment instructions.')

--- a/runway/_cli/commands/_gen_sample/_static_angular.py
+++ b/runway/_cli/commands/_gen_sample/_static_angular.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('static-angular',
                short_help='angular static site (static-angular)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def static_angular(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_static_react.py
+++ b/runway/_cli/commands/_gen_sample/_static_react.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('static-react',
                short_help='react static site (static-react)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def static_react(ctx, **_):

--- a/runway/_cli/commands/_gen_sample/_static_react.py
+++ b/runway/_cli/commands/_gen_sample/_static_react.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ... import options
 from .utils import TEMPLATES, copy_sample
 
 if sys.version_info.major > 2:
@@ -16,6 +17,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('static-react',
                short_help='react static site (static-react)')
+@options.debug
+@options.verbose
 @click.pass_context
 def static_react(ctx):
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_gen_sample/_static_react.py
+++ b/runway/_cli/commands/_gen_sample/_static_react.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def static_react(ctx):
+def static_react(ctx, **_):
     # type: (click.Context) -> None
     """Generate a sample static site project using React."""
     src = TEMPLATES / 'static-react'

--- a/runway/_cli/commands/_gen_sample/_static_react.py
+++ b/runway/_cli/commands/_gen_sample/_static_react.py
@@ -28,5 +28,5 @@ def static_react(ctx):
 
     copy_sample(ctx, src, dest)
 
-    LOGGER.info("Sample static React site repo created at %s", dest)
-    LOGGER.info('(see its README for setup and deployment instructions)')
+    LOGGER.success("Sample static React site repo created at %s", dest)
+    LOGGER.notice('See the README for setup and deployment instructions.')

--- a/runway/_cli/commands/_gen_sample/_tf.py
+++ b/runway/_cli/commands/_gen_sample/_tf.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.verbose
 @click.pass_context
-def tf(ctx):  # pylint: disable=invalid-name
+def tf(ctx, **_):  # pylint: disable=invalid-name
     # type: (click.Context) -> None
     """Generate a sample Terraform project."""
     src = TEMPLATES / 'terraform'

--- a/runway/_cli/commands/_gen_sample/_tf.py
+++ b/runway/_cli/commands/_gen_sample/_tf.py
@@ -31,4 +31,4 @@ def tf(ctx):  # pylint: disable=invalid-name
     if not (src / '.terraform-version').is_file():
         (dest / '.terraform-version').write_text(get_latest_tf_version())
 
-    LOGGER.info("Sample Terraform app created at %s", dest)
+    LOGGER.success("Sample Terraform app created at %s", dest)

--- a/runway/_cli/commands/_gen_sample/_tf.py
+++ b/runway/_cli/commands/_gen_sample/_tf.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('tf', short_help='tf (sampleapp.tf)')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def tf(ctx, **_):  # pylint: disable=invalid-name

--- a/runway/_cli/commands/_gen_sample/_tf.py
+++ b/runway/_cli/commands/_gen_sample/_tf.py
@@ -5,6 +5,7 @@ import sys
 import click
 
 from ....env_mgr.tfenv import get_latest_tf_version
+from ... import options
 from .utils import TEMPLATES, copy_sample
 
 if sys.version_info.major > 2:
@@ -16,6 +17,8 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 
 @click.command('tf', short_help='tf (sampleapp.tf)')
+@options.debug
+@options.verbose
 @click.pass_context
 def tf(ctx):  # pylint: disable=invalid-name
     # type: (click.Context) -> None

--- a/runway/_cli/commands/_init.py
+++ b/runway/_cli/commands/_init.py
@@ -29,6 +29,7 @@ deployments:
 
 @click.command('init', short_help='create runway.yml')
 @options.debug
+@options.verbose
 @click.pass_context
 def init(ctx, **_):
     # type: (click.Context, Any) -> None

--- a/runway/_cli/commands/_init.py
+++ b/runway/_cli/commands/_init.py
@@ -29,6 +29,7 @@ deployments:
 
 @click.command('init', short_help='create runway.yml')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def init(ctx, **_):

--- a/runway/_cli/commands/_init.py
+++ b/runway/_cli/commands/_init.py
@@ -36,6 +36,7 @@ def init(ctx, **_):
     """Create an example runway.yml file in the currect directory."""
     runway_yml = Path.cwd() / 'runway.yml'
 
+    LOGGER.verbose('checking for preexisting runway.yml file...')
     if runway_yml.is_file():
         LOGGER.error('There is already a %s file in the current directory',
                      runway_yml.name)
@@ -43,8 +44,8 @@ def init(ctx, **_):
 
     # TODO remove use of six when dropping python 2
     runway_yml.write_text(six.u(RUNWAY_YML))
-    LOGGER.info('runway.yml generated')
-    LOGGER.info(
+    LOGGER.success('runway.yml generated')
+    LOGGER.notice(
         'See addition getting started information at '
         'https://docs.onica.com/projects/runway/en/latest/getting_started.html'
     )

--- a/runway/_cli/commands/_kbenv/__init__.py
+++ b/runway/_cli/commands/_kbenv/__init__.py
@@ -15,6 +15,7 @@ COMMANDS = [install, run]
 
 @click.group('kbenv', short_help='kubectl (install|run)')
 @options.debug
+@options.verbose
 def kbenv(**_):
     # type: (Any) -> None
     """kubectl version management and execution.

--- a/runway/_cli/commands/_kbenv/__init__.py
+++ b/runway/_cli/commands/_kbenv/__init__.py
@@ -15,6 +15,7 @@ COMMANDS = [install, run]
 
 @click.group('kbenv', short_help='kubectl (install|run)')
 @options.debug
+@options.no_color
 @options.verbose
 def kbenv(**_):
     # type: (Any) -> None

--- a/runway/_cli/commands/_kbenv/_install.py
+++ b/runway/_cli/commands/_kbenv/_install.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('install', short_help='install kubectl')
 @click.argument('version', metavar='[<version>]', required=False)
 @options.debug
+@options.verbose
 def install(version, **_):
     # type: (str, Any) -> None
     """Install the specified <version> of kubectl (e.g. v1.14.0).

--- a/runway/_cli/commands/_kbenv/_install.py
+++ b/runway/_cli/commands/_kbenv/_install.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('install', short_help='install kubectl')
 @click.argument('version', metavar='[<version>]', required=False)
 @options.debug
+@options.no_color
 @options.verbose
 def install(version, **_):
     # type: (str, Any) -> None

--- a/runway/_cli/commands/_kbenv/_run.py
+++ b/runway/_cli/commands/_kbenv/_run.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.verbose
 @click.pass_context
 def run(ctx, args, **_):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_kbenv/_run.py
+++ b/runway/_cli/commands/_kbenv/_run.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def run(ctx, args, **_):

--- a/runway/_cli/commands/_plan.py
+++ b/runway/_cli/commands/_plan.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.ci
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.tags
 @options.verbose
 @click.pass_context

--- a/runway/_cli/commands/_plan.py
+++ b/runway/_cli/commands/_plan.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.deploy_environment
 @options.tags
+@options.verbose
 @click.pass_context
 def plan(ctx, tags, **_):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_preflight.py
+++ b/runway/_cli/commands/_preflight.py
@@ -17,5 +17,5 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.pass_context
 def preflight(ctx, **kwargs):
     """Alias of "runway test"."""
-    LOGGER.debug('forwarding to test...')
+    LOGGER.verbose('forwarding to test...')
     ctx.forward(test, **kwargs)

--- a/runway/_cli/commands/_preflight.py
+++ b/runway/_cli/commands/_preflight.py
@@ -13,6 +13,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('preflight', short_help='alias of test')
 @options.debug
 @options.deploy_environment
+@options.verbose
 @click.pass_context
 def preflight(ctx, **kwargs):
     """Alias of "runway test"."""

--- a/runway/_cli/commands/_preflight.py
+++ b/runway/_cli/commands/_preflight.py
@@ -13,6 +13,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('preflight', short_help='alias of test')
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.verbose
 @click.pass_context
 def preflight(ctx, **kwargs):

--- a/runway/_cli/commands/_run_aws.py
+++ b/runway/_cli/commands/_run_aws.py
@@ -14,6 +14,7 @@ from .. import options
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def run_aws(ctx, args, **_):

--- a/runway/_cli/commands/_run_aws.py
+++ b/runway/_cli/commands/_run_aws.py
@@ -14,6 +14,7 @@ from .. import options
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.verbose
 @click.pass_context
 def run_aws(ctx, args, **_):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_run_python.py
+++ b/runway/_cli/commands/_run_python.py
@@ -17,6 +17,7 @@ else:
 @click.argument('filename', metavar='<filename>', required=True,
                 type=click.Path(exists=True, dir_okay=False))
 @options.debug
+@options.verbose
 def run_python(filename, **_):
     # type: (str, Any) -> None
     """Execute a python script using a bundled copy of python.

--- a/runway/_cli/commands/_run_python.py
+++ b/runway/_cli/commands/_run_python.py
@@ -17,6 +17,7 @@ else:
 @click.argument('filename', metavar='<filename>', required=True,
                 type=click.Path(exists=True, dir_okay=False))
 @options.debug
+@options.no_color
 @options.verbose
 def run_python(filename, **_):
     # type: (str, Any) -> None

--- a/runway/_cli/commands/_run_stacker.py
+++ b/runway/_cli/commands/_run_stacker.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.no_color
 @options.verbose
 def run_stacker(args, **_):
     # type: (Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_run_stacker.py
+++ b/runway/_cli/commands/_run_stacker.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.verbose
 def run_stacker(args, **_):
     # type: (Tuple[str, ...], Any) -> None
     """Execute a command using the "shimmed" Stacker (aka CFNgin).

--- a/runway/_cli/commands/_takeoff.py
+++ b/runway/_cli/commands/_takeoff.py
@@ -21,5 +21,5 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 def takeoff(ctx, **kwargs):
     # type: (click.Context, Tuple[str, ...], Any) -> None
     """Alias of "runway deploy"."""
-    LOGGER.debug('forwarding to deploy...')
+    LOGGER.verbose('forwarding to deploy...')
     ctx.forward(deploy, **kwargs)

--- a/runway/_cli/commands/_takeoff.py
+++ b/runway/_cli/commands/_takeoff.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.deploy_environment
 @options.tags
+@options.verbose
 @click.pass_context
 def takeoff(ctx, **kwargs):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_takeoff.py
+++ b/runway/_cli/commands/_takeoff.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.ci
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.tags
 @options.verbose
 @click.pass_context

--- a/runway/_cli/commands/_taxi.py
+++ b/runway/_cli/commands/_taxi.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.debug
 @options.deploy_environment
 @options.tags
+@options.verbose
 @click.pass_context
 def taxi(ctx, **kwargs):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_taxi.py
+++ b/runway/_cli/commands/_taxi.py
@@ -21,5 +21,5 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 def taxi(ctx, **kwargs):
     # type: (click.Context, Tuple[str, ...], Any) -> None
     """Alias of "runway plan"."""
-    LOGGER.debug('forwarding to plan...')
+    LOGGER.verbose('forwarding to plan...')
     ctx.forward(plan, **kwargs)

--- a/runway/_cli/commands/_taxi.py
+++ b/runway/_cli/commands/_taxi.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @options.ci
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.tags
 @options.verbose
 @click.pass_context

--- a/runway/_cli/commands/_test.py
+++ b/runway/_cli/commands/_test.py
@@ -13,6 +13,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('test', short_help='run tests')
 @options.debug
 @options.deploy_environment
+@options.verbose
 @click.pass_context
 def test(ctx, **_):
     """Execute tests as defined in the Runway config.

--- a/runway/_cli/commands/_test.py
+++ b/runway/_cli/commands/_test.py
@@ -13,6 +13,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('test', short_help='run tests')
 @options.debug
 @options.deploy_environment
+@options.no_color
 @options.verbose
 @click.pass_context
 def test(ctx, **_):

--- a/runway/_cli/commands/_tfenv/__init__.py
+++ b/runway/_cli/commands/_tfenv/__init__.py
@@ -15,6 +15,7 @@ COMMANDS = [install, run]
 
 @click.group('tfenv', short_help='terraform (install|run)')
 @options.debug
+@options.no_color
 @options.verbose
 def tfenv(**_):
     # type: (Any) -> None

--- a/runway/_cli/commands/_tfenv/__init__.py
+++ b/runway/_cli/commands/_tfenv/__init__.py
@@ -15,6 +15,7 @@ COMMANDS = [install, run]
 
 @click.group('tfenv', short_help='terraform (install|run)')
 @options.debug
+@options.verbose
 def tfenv(**_):
     # type: (Any) -> None
     """Terraform version management and execution.

--- a/runway/_cli/commands/_tfenv/_install.py
+++ b/runway/_cli/commands/_tfenv/_install.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('install', short_help='install terraform')
 @click.argument('version', metavar='[<version>]', required=False, default=None)
 @options.debug
+@options.verbose
 def install(version, **_):
     # type: (str, Any) -> None
     """Install the specified <version> of Terraform (e.g. 0.12.0).

--- a/runway/_cli/commands/_tfenv/_install.py
+++ b/runway/_cli/commands/_tfenv/_install.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 @click.command('install', short_help='install terraform')
 @click.argument('version', metavar='[<version>]', required=False, default=None)
 @options.debug
+@options.no_color
 @options.verbose
 def install(version, **_):
     # type: (str, Any) -> None

--- a/runway/_cli/commands/_tfenv/_run.py
+++ b/runway/_cli/commands/_tfenv/_run.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.verbose
 @click.pass_context
 def run(ctx, args, **_):
     # type: (click.Context, Tuple[str, ...], Any) -> None

--- a/runway/_cli/commands/_tfenv/_run.py
+++ b/runway/_cli/commands/_tfenv/_run.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
                context_settings={'ignore_unknown_options': True})
 @click.argument('args', metavar='<args>', nargs=-1, required=True)
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def run(ctx, args, **_):

--- a/runway/_cli/commands/_whichenv.py
+++ b/runway/_cli/commands/_whichenv.py
@@ -10,6 +10,7 @@ from .. import options
 
 @click.command('whichenv', short_help='current deploy environment')
 @options.debug
+@options.verbose
 @click.pass_context
 def whichenv(ctx, **_):  # noqa: D301
     """Print the current deploy environment name to stdout.

--- a/runway/_cli/commands/_whichenv.py
+++ b/runway/_cli/commands/_whichenv.py
@@ -12,6 +12,7 @@ LOGGER = logging.getLogger(__name__.replace('._', '.'))
 
 @click.command('whichenv', short_help='current deploy environment')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def whichenv(ctx, **_):  # noqa: D301

--- a/runway/_cli/commands/_whichenv.py
+++ b/runway/_cli/commands/_whichenv.py
@@ -7,6 +7,8 @@ import click
 from ...util import SafeHaven
 from .. import options
 
+LOGGER = logging.getLogger(__name__.replace('._', '.'))
+
 
 @click.command('whichenv', short_help='current deploy environment')
 @options.debug
@@ -24,7 +26,7 @@ def whichenv(ctx, **_):  # noqa: D301
       - current working directory
 
     """
-    if not ctx.obj.debug:
+    if not (ctx.obj.debug or ctx.obj.verbose):
         logging.getLogger('runway').setLevel(logging.ERROR)  # suppress warnings
     with SafeHaven(environ={'CI': '1'}):  # prevent prompts
         click.echo(ctx.obj.env.name)

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -63,15 +63,17 @@ class LogSettings(object):
         'level_styles': os.getenv('COLOREDLOGS_LEVEL_STYLES')
     }
 
-    def __init__(self, debug=0, verbose=False):
+    def __init__(self, debug=0, no_color=False, verbose=False):
         """Instantiate class.
 
         Args:
             debug (int): Debug level.
+            no_color (bool): Disable color in Runway's logs.
             verbose (bool): Whether to display verbose logs.
 
         """
         self.debug = debug
+        self.no_color = no_color
         self.verbose = verbose
 
     @property
@@ -100,7 +102,7 @@ class LogSettings(object):
         """
         if self.ENV['fmt']:
             return self.ENV['fmt']
-        if self.debug or self.verbose:
+        if self.debug or self.no_color or self.verbose:
             return LOG_FORMAT_VERBOSE
         return LOG_FORMAT
 
@@ -115,6 +117,9 @@ class LogSettings(object):
             Dict[str, Any]
 
         """
+        if self.no_color:
+            return {}
+
         result = LOG_FIELD_STYLES.copy()
         if self.ENV['field_styles']:
             result.update(coloredlogs.parse_encoded_styles(
@@ -133,6 +138,9 @@ class LogSettings(object):
             Dict[str, Any]
 
         """
+        if self.no_color:
+            return {}
+
         result = LOG_LEVEL_STYLES.copy()
         if self.ENV['level_styles']:
             result.update(coloredlogs.parse_encoded_styles(
@@ -163,8 +171,11 @@ def setup_logging(*_, **kwargs):
         debug (int): Debug level (0-2).
 
     """
-    settings = LogSettings(debug=kwargs.pop('debug', 0),
-                           verbose=kwargs.pop('verbose', False))
+    settings = LogSettings(
+        debug=kwargs.pop('debug', 0),
+        no_color=kwargs.pop('no_color', False),
+        verbose=kwargs.pop('verbose', False)
+    )
 
     coloredlogs.install(settings.log_level, logger=LOGGER,
                         **settings.coloredlogs)

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -11,13 +11,15 @@ from ..util import cached_property
 # COLOR_FORMAT = "%(levelname)s:%(name)s:\033[%(color)sm%(message)s\033[39m"
 LOGGER = logging.getLogger('runway')
 
-LOG_FORMAT = '%(levelname)s:runway:%(message)s'
-LOG_FORMAT_VERBOSE = '%(levelname)s:%(name)s:%(message)s'
+LOG_FORMAT = '[%(programname)s] %(message)s'
+LOG_FORMAT_VERBOSE = logging.BASIC_FORMAT
 LOG_FIELD_STYLES = {
     'asctime': {},
     'hostname': {},
     'levelname': {},
+    'message': {},
     'name': {},
+    'prefix': {},
     'programname': {}
 }
 LOG_LEVEL_STYLES = {
@@ -185,6 +187,7 @@ def setup_logging(*_, **kwargs):
                         logger=botocore_logger, **settings.coloredlogs)
     coloredlogs.install(settings.dependency_log_level,
                         logger=urllib3_logger, **settings.coloredlogs)
+
     LOGGER.debug('runway log level: %s', LOGGER.getEffectiveLevel().name)
     LOGGER.debug('dependency log levels: %s', {
         'botocore': botocore_logger.getEffectiveLevel(),

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -123,18 +123,6 @@ class LogSettings(object):
         return result
 
     @cached_property
-    def dependency_log_level(self):
-        """Return dependency log level.
-
-        Returns:
-            LogLevel
-
-        """
-        if self.debug > 1:
-            return LogLevels.DEBUG
-        return LogLevels.ERROR
-
-    @cached_property
     def level_styles(self):
         """Return log level styles.
 
@@ -153,8 +141,8 @@ class LogSettings(object):
         return result
 
     @cached_property
-    def runway_log_level(self):
-        """Return Runway log level.
+    def log_level(self):
+        """Return log level to use.
 
         Returns:
             LogLevel
@@ -178,19 +166,13 @@ def setup_logging(*_, **kwargs):
     settings = LogSettings(debug=kwargs.pop('debug', 0),
                            verbose=kwargs.pop('verbose', False))
 
-    botocore_logger = logging.getLogger('botocore')
-    urllib3_logger = logging.getLogger('urllib3')
-
-    coloredlogs.install(settings.runway_log_level, logger=LOGGER,
+    coloredlogs.install(settings.log_level, logger=LOGGER,
                         **settings.coloredlogs)
-    coloredlogs.install(settings.dependency_log_level,
-                        logger=botocore_logger, **settings.coloredlogs)
-    coloredlogs.install(settings.dependency_log_level,
-                        logger=urllib3_logger, **settings.coloredlogs)
+    LOGGER.debug('runway log level: %s', LOGGER.getEffectiveLevel())
 
-    LOGGER.debug('runway log level: %s', LOGGER.getEffectiveLevel().name)
-    LOGGER.debug('dependency log levels: %s', {
-        'botocore': botocore_logger.getEffectiveLevel(),
-        'urllib3': urllib3_logger.getEffectiveLevel()
-    })
+    if settings.debug == 2:
+        coloredlogs.install(settings.log_level,
+                            logger=logging.getLogger('botocore'),
+                            **settings.coloredlogs)
+        LOGGER.debug('set dependency log level to debug')
     LOGGER.debug('initalized logging for Runway')

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -11,8 +11,8 @@ from ..util import cached_property
 # COLOR_FORMAT = "%(levelname)s:%(name)s:\033[%(color)sm%(message)s\033[39m"
 LOGGER = logging.getLogger('runway')
 
-LOG_FORMAT = '%(levelname)s:runway: %(message)s'
-LOG_FORMAT_VERBOSE = '%(levelname)s:%(name)s: %(message)s'
+LOG_FORMAT = '%(levelname)s:runway:%(message)s'
+LOG_FORMAT_VERBOSE = '%(levelname)s:%(name)s:%(message)s'
 LOG_FIELD_STYLES = {
     'asctime': {},
     'hostname': {},

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -58,9 +58,9 @@ class LogSettings(object):
     """CLI log settings."""
 
     ENV = {
-        'field_styles': os.getenv('COLOREDLOGS_FIELD_STYLES'),
-        'fmt': os.getenv('COLOREDLOGS_LOG_FORMAT'),
-        'level_styles': os.getenv('COLOREDLOGS_LEVEL_STYLES')
+        'field_styles': os.getenv('RUNWAY_LOG_FIELD_STYLES'),
+        'fmt': os.getenv('RUNWAY_LOG_FORMAT'),
+        'level_styles': os.getenv('RUNWAY_LOG_LEVEL_STYLES')
     }
 
     def __init__(self, debug=0, no_color=False, verbose=False):
@@ -94,7 +94,7 @@ class LogSettings(object):
     def fmt(self):
         """Return log record format.
 
-        If "COLOREDLOGS_LOG_FORMAT" exists in the environment, it will be used.
+        If "RUNWAY_LOG_FORMAT" exists in the environment, it will be used.
 
         Returns:
             str
@@ -110,7 +110,7 @@ class LogSettings(object):
     def field_styles(self):
         """Return log field styles.
 
-        If "COLOREDLOGS_FIELD_STYLES" exists in the environment, it will be
+        If "RUNWAY_LOG_FIELD_STYLES" exists in the environment, it will be
         used to update the Runway LOG_FIELD_STYLES.
 
         Returns:
@@ -131,7 +131,7 @@ class LogSettings(object):
     def level_styles(self):
         """Return log level styles.
 
-        If "COLOREDLOGS_LEVEL_STYLES" exists in the environment, it will be
+        If "RUNWAY_LOG_LEVEL_STYLES" exists in the environment, it will be
         used to update the Runway LOG_LEVEL_STYLES.
 
         Returns:

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -1,30 +1,24 @@
 """Runway CLI logging setup."""
 import logging
+import os
 
 import coloredlogs
 
 from runway import LogLevels
 
+from ..util import cached_property
+
 # COLOR_FORMAT = "%(levelname)s:%(name)s:\033[%(color)sm%(message)s\033[39m"
 LOGGER = logging.getLogger('runway')
 
-LOG_FORMAT = '%(name)s: %(message)s'
-LOG_FORMAT_W_LEVEL = '[%(levelname)s]%(name)s: %(message)s'
+LOG_FORMAT = '%(levelname)s:runway: %(message)s'
+LOG_FORMAT_VERBOSE = '%(levelname)s:%(name)s: %(message)s'
 LOG_FIELD_STYLES = {
-    'asctime': {
-        'color': 'green'
-    },
-    'hostname': {
-        'color': 'magenta'
-    },
-    'levelname': {
-        # 'color': 'black',
-        # 'bold': True
-    },
+    'asctime': {},
+    'hostname': {},
+    'levelname': {},
     'name': {},
-    'programname': {
-        'color': 'cyan'
-    }
+    'programname': {}
 }
 LOG_LEVEL_STYLES = {
     'critical': {
@@ -39,7 +33,7 @@ LOG_LEVEL_STYLES = {
     },
     'info': {},
     'notice': {
-        'color': 'magenta'
+        'color': 'yellow'
     },
     'spam': {
         'color': 'green',
@@ -53,32 +47,147 @@ LOG_LEVEL_STYLES = {
         'color': 'cyan'
     },
     'warning': {
-        'color': 'yellow'
+        'color': 214
     }
 }
 
 
+class LogSettings(object):
+    """CLI log settings."""
+
+    ENV = {
+        'field_styles': os.getenv('COLOREDLOGS_FIELD_STYLES'),
+        'fmt': os.getenv('COLOREDLOGS_LOG_FORMAT'),
+        'level_styles': os.getenv('COLOREDLOGS_LEVEL_STYLES')
+    }
+
+    def __init__(self, debug=0, verbose=False):
+        """Instantiate class.
+
+        Args:
+            debug (int): Debug level.
+            verbose (bool): Whether to display verbose logs.
+
+        """
+        self.debug = debug
+        self.verbose = verbose
+
+    @property
+    def coloredlogs(self):
+        """Return settings for coloredlogs.
+
+        Returns:
+            Dict[str, Any]
+
+        """
+        return {
+            'fmt': self.fmt,
+            'field_styles': self.field_styles,
+            'level_styles': self.level_styles
+        }
+
+    @cached_property
+    def fmt(self):
+        """Return log record format.
+
+        If "COLOREDLOGS_LOG_FORMAT" exists in the environment, it will be used.
+
+        Returns:
+            str
+
+        """
+        if self.ENV['fmt']:
+            return self.ENV['fmt']
+        if self.debug or self.verbose:
+            return LOG_FORMAT_VERBOSE
+        return LOG_FORMAT
+
+    @cached_property
+    def field_styles(self):
+        """Return log field styles.
+
+        If "COLOREDLOGS_FIELD_STYLES" exists in the environment, it will be
+        used to update the Runway LOG_FIELD_STYLES.
+
+        Returns:
+            Dict[str, Any]
+
+        """
+        result = LOG_FIELD_STYLES.copy()
+        if self.ENV['field_styles']:
+            result.update(coloredlogs.parse_encoded_styles(
+                self.ENV['field_styles']
+            ))
+        return result
+
+    @cached_property
+    def dependency_log_level(self):
+        """Return dependency log level.
+
+        Returns:
+            LogLevel
+
+        """
+        if self.debug > 1:
+            return LogLevels.DEBUG
+        return LogLevels.ERROR
+
+    @cached_property
+    def level_styles(self):
+        """Return log level styles.
+
+        If "COLOREDLOGS_LEVEL_STYLES" exists in the environment, it will be
+        used to update the Runway LOG_LEVEL_STYLES.
+
+        Returns:
+            Dict[str, Any]
+
+        """
+        result = LOG_LEVEL_STYLES.copy()
+        if self.ENV['level_styles']:
+            result.update(coloredlogs.parse_encoded_styles(
+                self.ENV['level_styles']
+            ))
+        return result
+
+    @cached_property
+    def runway_log_level(self):
+        """Return Runway log level.
+
+        Returns:
+            LogLevel
+
+        """
+        if self.debug:
+            return LogLevels.DEBUG
+        if self.verbose:
+            return LogLevels.VERBOSE
+        return LogLevels.INFO
+
+
 # TODO implement propper keyword-only args when dropping python 2
-# def setup_logging(*: Any, debug: int) -> None:
-def setup_logging(_=None, **kwargs):
+def setup_logging(*_, **kwargs):
     """Configure log settings for Runway CLI.
 
-    Args:
+    Keyword Args:
         debug (int): Debug level (0-2).
 
     """
-    debug = kwargs.pop('debug', 0)
-    log_settings = {
-        'fmt': LOG_FORMAT_W_LEVEL,
-        'field_styles': LOG_FIELD_STYLES,
-        'level_styles': LOG_LEVEL_STYLES
-    }
-    runway_log_level = LogLevels.INFO if not debug else LogLevels.DEBUG
-    dependency_log_level = LogLevels.ERROR if debug < 2 else LogLevels.DEBUG
+    settings = LogSettings(debug=kwargs.pop('debug', 0),
+                           verbose=kwargs.pop('verbose', False))
 
-    coloredlogs.install(runway_log_level, logger=LOGGER, **log_settings)
-    coloredlogs.install(dependency_log_level,
-                        logger=logging.getLogger('botocore'), **log_settings)
-    coloredlogs.install(dependency_log_level,
-                        logger=logging.getLogger('urllib3'), **log_settings)
-    LOGGER.debug('inatalized logging for Runway')
+    botocore_logger = logging.getLogger('botocore')
+    urllib3_logger = logging.getLogger('urllib3')
+
+    coloredlogs.install(settings.runway_log_level, logger=LOGGER,
+                        **settings.coloredlogs)
+    coloredlogs.install(settings.dependency_log_level,
+                        logger=botocore_logger, **settings.coloredlogs)
+    coloredlogs.install(settings.dependency_log_level,
+                        logger=urllib3_logger, **settings.coloredlogs)
+    LOGGER.debug('runway log level: %s', LOGGER.getEffectiveLevel().name)
+    LOGGER.debug('dependency log levels: %s', {
+        'botocore': botocore_logger.getEffectiveLevel(),
+        'urllib3': urllib3_logger.getEffectiveLevel()
+    })
+    LOGGER.debug('initalized logging for Runway')

--- a/runway/_cli/main.py
+++ b/runway/_cli/main.py
@@ -50,6 +50,8 @@ class _CliGroup(click.Group):  # pylint: disable=too-few-public-methods
                             action='count')
         parser.add_argument('-e', '--deploy-environment',
                             default=os.getenv('DEPLOY_ENVIRONMENT'))
+        parser.add_argument('--no-color', action='store_true',
+                            default=bool(os.getenv('RUNWAY_NO_COLOR')))
         parser.add_argument('--verbose', action='store_true',
                             default=bool(os.getenv('VERBOSE')))
         args, _ = parser.parse_known_args(list(ctx.args))
@@ -59,6 +61,7 @@ class _CliGroup(click.Group):  # pylint: disable=too-few-public-methods
 @click.group(context_settings=CLICK_CONTEXT_SETTINGS, cls=_CliGroup)
 @click.version_option(__version__, message='%(version)s')
 @options.debug
+@options.no_color
 @options.verbose
 @click.pass_context
 def cli(ctx, **_):
@@ -69,7 +72,11 @@ def cli(ctx, **_):
 
     """
     opts = ctx.meta['global.options']
-    setup_logging(debug=opts['debug'], verbose=opts['verbose'])
+    setup_logging(
+        debug=opts['debug'],
+        no_color=opts['no_color'],
+        verbose=opts['verbose']
+    )
     ctx.obj = CliContext(**opts)
 
 

--- a/runway/_cli/main.py
+++ b/runway/_cli/main.py
@@ -69,7 +69,7 @@ def cli(ctx, **_):
 
     """
     opts = ctx.meta['global.options']
-    setup_logging(debug=opts['debug'])
+    setup_logging(debug=opts['debug'], verbose=opts['verbose'])
     ctx.obj = CliContext(**opts)
 
 

--- a/runway/_cli/main.py
+++ b/runway/_cli/main.py
@@ -46,9 +46,12 @@ class _CliGroup(click.Group):  # pylint: disable=too-few-public-methods
         parser = argparse.ArgumentParser(add_help=False)
         parser.add_argument('--ci', action='store_true',
                             default=bool(os.getenv('CI')))
-        parser.add_argument('--debug', default=int(os.getenv('DEBUG', '0')), action='count')
+        parser.add_argument('--debug', default=int(os.getenv('DEBUG', '0')),
+                            action='count')
         parser.add_argument('-e', '--deploy-environment',
                             default=os.getenv('DEPLOY_ENVIRONMENT'))
+        parser.add_argument('--verbose', action='store_true',
+                            default=bool(os.getenv('VERBOSE')))
         args, _ = parser.parse_known_args(list(ctx.args))
         return vars(args)
 
@@ -56,6 +59,7 @@ class _CliGroup(click.Group):  # pylint: disable=too-few-public-methods
 @click.group(context_settings=CLICK_CONTEXT_SETTINGS, cls=_CliGroup)
 @click.version_option(__version__, message='%(version)s')
 @options.debug
+@options.verbose
 @click.pass_context
 def cli(ctx, **_):
     # type: (click.Context, Any) -> None

--- a/runway/_cli/options.py
+++ b/runway/_cli/options.py
@@ -19,6 +19,12 @@ deploy_environment = click.option('-e', '--deploy-environment',
                                   help='Manually specify the name of the '
                                   'deploy environment.')
 
+no_color = click.option('--no-color',
+                        default=False,
+                        envvar='RUNWAY_NO_COLOR',
+                        is_flag=True,
+                        help="Disable color in Runway's logs.")
+
 tags = click.option('--tag', 'tags',
                     metavar='<tag>...',
                     multiple=True,

--- a/runway/_cli/options.py
+++ b/runway/_cli/options.py
@@ -27,3 +27,9 @@ tags = click.option('--tag', 'tags',
                     ' list of tags that are treated as "AND". '
                     '(e.g. "--tag <tag1> --tag <tag2>" would select all modules'
                     ' with BOTH tags).')
+
+verbose = click.option('--verbose',
+                       default=False,
+                       envvar='VERBOSE',
+                       is_flag=True,
+                       help='Display Runway verbose logs.')

--- a/runway/_cli/utils.py
+++ b/runway/_cli/utils.py
@@ -67,7 +67,7 @@ class CliContext(MutableMapping):
         try:
             return Config.find_config_file(config_dir=self.root_dir)
         except SystemExit:
-            LOGGER.verbose('checking parent directory...')
+            LOGGER.info('trying parent directory')
             self.root_dir = self.root_dir.parent
             self.env.root_dir = self.root_dir
             return Config.find_config_file(config_dir=self.root_dir)

--- a/runway/_cli/utils.py
+++ b/runway/_cli/utils.py
@@ -25,12 +25,22 @@ LOGGER = logging.getLogger(__name__)
 class CliContext(MutableMapping):
     """CLI context object."""
 
-    def __init__(self, ci=False, debug=0, deploy_environment=None, **_):
+    def __init__(self, ci=False, debug=0, deploy_environment=None,
+                 verbose=False, **_):
         # type: (bool, int, Optional[str], Any) -> None
-        """Instantiate class."""
+        """Instantiate class.
+
+        Keyword Args:
+            ci (bool): Whether Runway is being run in non-interactive mode.
+            debug (int): Debug level
+            deploy_environment (str): Name of the deploy environment.
+            verbose (bool): Whether to display verbose logs.
+
+        """
         self._deploy_environment = deploy_environment
         self.debug = debug
         self.root_dir = Path.cwd()
+        self.verbose = verbose
         if ci:  # prevents unnecessary loading of runway config
             self.env.ci = ci
 
@@ -57,7 +67,7 @@ class CliContext(MutableMapping):
         try:
             return Config.find_config_file(config_dir=self.root_dir)
         except SystemExit:
-            LOGGER.debug('checking parent directory...')
+            LOGGER.verbose('checking parent directory...')
             self.root_dir = self.root_dir.parent
             self.env.root_dir = self.root_dir
             return Config.find_config_file(config_dir=self.root_dir)

--- a/runway/_logging.py
+++ b/runway/_logging.py
@@ -1,0 +1,72 @@
+"""Runway logging."""
+import logging
+from enum import IntEnum
+
+
+class LogLevels(IntEnum):
+    """All available log levels."""
+
+    NOTSET: int = 0
+    DEBUG: int = 10
+    VERBOSE: int = 15
+    INFO: int = 20
+    NOTICE: int = 25
+    WARNING: int = 30
+    SUCCESS: int = 35
+    ERROR: int = 40
+    CRITICAL: int = 50
+
+    @classmethod
+    def has_value(cls, value: int) -> bool:
+        """Check if IntEnum has a value."""
+        return value in cls._value2member_map_   # pylint: disable=no-member
+
+
+class RunwayLogger(logging.Logger):
+    """Extend built-in logger with additional levels."""
+
+    def __init__(self, name, level=logging.NOTSET):
+        """Instantiate the class.
+
+        Args:
+            name (str): Logger name.
+            level (int): Log level.
+
+        """
+        super().__init__(name, level)
+        logging.addLevelName(LogLevels.VERBOSE, LogLevels.VERBOSE.name)
+        logging.addLevelName(LogLevels.NOTICE, LogLevels.NOTICE.name)
+        logging.addLevelName(LogLevels.SUCCESS, LogLevels.SUCCESS.name)
+
+    def verbose(self, msg, *args, **kwargs):
+        """Log 'msg % args' with severity `VERBOSE`.
+
+        Args:
+            msg (Union[str, Exception]): String template or exception to use
+                for the log record.
+
+        """
+        if self.isEnabledFor(LogLevels.VERBOSE):
+            self._log(LogLevels.VERBOSE, msg, args, **kwargs)
+
+    def notice(self, msg, *args, **kwargs):
+        """Log 'msg % args' with severity `NOTICE`.
+
+        Args:
+            msg (Union[str, Exception]): String template or exception to use
+                for the log record.
+
+        """
+        if self.isEnabledFor(LogLevels.NOTICE):
+            self._log(LogLevels.NOTICE, msg, args, **kwargs)
+
+    def success(self, msg, *args, **kwargs):
+        """Log 'msg % args' with severity `SUCCESS`.
+
+        Args:
+            msg (Union[str, Exception]): String template or exception to use
+                for the log record.
+
+        """
+        if self.isEnabledFor(LogLevels.SUCCESS):
+            self._log(LogLevels.SUCCESS, msg, args, **kwargs)

--- a/runway/_logging.py
+++ b/runway/_logging.py
@@ -102,7 +102,7 @@ class RunwayLogger(logging.Logger):
             level (int): Log level.
 
         """
-        super().__init__(name, level)
+        super(RunwayLogger, self).__init__(name, level)
         logging.addLevelName(LogLevels.VERBOSE, LogLevels.VERBOSE.name)
         logging.addLevelName(LogLevels.NOTICE, LogLevels.NOTICE.name)
         logging.addLevelName(LogLevels.SUCCESS, LogLevels.SUCCESS.name)

--- a/runway/_logging.py
+++ b/runway/_logging.py
@@ -31,7 +31,7 @@ class PrefixAdaptor(logging.LoggerAdapter):
 
     """
 
-    def __init__(self, prefix, logger, prefix_template='{prefix}: {msg}'):
+    def __init__(self, prefix, logger, prefix_template='{prefix}:{msg}'):
         """Instantiate class.
 
         Args:

--- a/runway/_logging.py
+++ b/runway/_logging.py
@@ -6,18 +6,18 @@ from enum import IntEnum
 class LogLevels(IntEnum):
     """All available log levels."""
 
-    NOTSET: int = 0
-    DEBUG: int = 10
-    VERBOSE: int = 15
-    INFO: int = 20
-    NOTICE: int = 25
-    WARNING: int = 30
-    SUCCESS: int = 35
-    ERROR: int = 40
-    CRITICAL: int = 50
+    NOTSET = 0
+    DEBUG = 10
+    VERBOSE = 15
+    INFO = 20
+    NOTICE = 25
+    WARNING = 30
+    SUCCESS = 35
+    ERROR = 40
+    CRITICAL = 50
 
     @classmethod
-    def has_value(cls, value: int) -> bool:
+    def has_value(cls, value):
         """Check if IntEnum has a value."""
         return value in cls._value2member_map_   # pylint: disable=no-member
 

--- a/runway/_logging.py
+++ b/runway/_logging.py
@@ -47,6 +47,36 @@ class PrefixAdaptor(logging.LoggerAdapter):
         self.prefix = prefix
         self.prefix_template = prefix_template
 
+    # TODO remove when dropping python 2
+    def getEffectiveLevel(self):  # noqa pylint: disable=invalid-name
+        # type: () -> int
+        """ Get the effective level for the underlying logger.
+
+        Python 2 backport.
+
+        """
+        return self.logger.getEffectiveLevel()
+
+    # TODO remove when dropping python 2
+    def hasHandlers(self):  # noqa pylint: disable=invalid-name
+        # type: () -> bool
+        """See if the underlying logger has any handlers.
+
+        Python 2 backport.
+
+        """
+        return self.logger.hasHandlers()
+
+    # TODO remove when dropping python 2
+    def isEnabledFor(self, level):  # noqa pylint: disable=invalid-name
+        # type: (int) -> bool
+        """Is this logger enabled for level 'level'?
+
+        Python 2 backport.
+
+        """
+        return self.logger.isEnabledFor(level)
+
     def notice(self, msg, *args, **kwargs):
         """Delegate a notice call to the underlying logger.
 
@@ -69,6 +99,16 @@ class PrefixAdaptor(logging.LoggerAdapter):
 
         """
         return self.prefix_template.format(prefix=self.prefix, msg=msg), kwargs
+
+    # TODO remove when dropping python 2
+    def setLevel(self, level):  # noqa pylint: disable=invalid-name
+        # type: () -> None
+        """Set the specified level on the underlying logger.
+
+        Python 2 backport.
+
+        """
+        self.logger.setLevel(level)
 
     def success(self, msg, *args, **kwargs):
         """Delegate a success call to the underlying logger.

--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -95,6 +95,7 @@ class BaseAction(object):
     """
 
     DESCRIPTION = 'Base action'
+    NAME = None
 
     def __init__(self, context, provider_builder=None, cancel=None):
         """Instantiate class.
@@ -278,4 +279,10 @@ class BaseAction(object):
     def _tail_stack(self, stack, cancel, retries=0, **kwargs):
         """Tail a stack's event stream."""
         provider = self.build_provider(stack)
-        return provider.tail_stack(stack, cancel, retries, **kwargs)
+        return provider.tail_stack(
+            stack,
+            cancel,
+            action=self.NAME,
+            retries=retries,
+            **kwargs
+        )

--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -198,7 +198,7 @@ class BaseAction(object):
                 raise
 
         if template_exists and not force:
-            LOGGER.debug("Cloudformation template %s already exists.",
+            LOGGER.debug("CloudFormation template already exists: %s",
                          template_url)
             return template_url
         self.s3_conn.put_object(Bucket=self.bucket_name,
@@ -206,7 +206,7 @@ class BaseAction(object):
                                 Body=blueprint.rendered,
                                 ServerSideEncryption='AES256',
                                 ACL='bucket-owner-full-control')
-        LOGGER.debug("Blueprint %s pushed to %s.", blueprint.name,
+        LOGGER.debug("blueprint %s pushed to %s", blueprint.name,
                      template_url)
         return template_url
 

--- a/runway/cfngin/actions/build.py
+++ b/runway/cfngin/actions/build.py
@@ -202,6 +202,7 @@ class Action(BaseAction):
     """
 
     DESCRIPTION = 'Create/Update stacks'
+    NAME = 'build'
 
     @staticmethod
     def build_parameters(stack, provider_stack=None):

--- a/runway/cfngin/actions/destroy.py
+++ b/runway/cfngin/actions/destroy.py
@@ -45,7 +45,7 @@ class Action(BaseAction):
         try:
             provider_stack = provider.get_stack(stack.fqn)
         except StackDoesNotExist:
-            LOGGER.debug("Stack %s does not exist.", stack.fqn)
+            LOGGER.debug("%s:stack does not exist", stack.fqn)
             # Once the stack has been destroyed, it doesn't exist. If the
             # status of the step was SUBMITTED, we know we just deleted it,
             # otherwise it should be skipped
@@ -54,7 +54,7 @@ class Action(BaseAction):
             return StackDoesNotExistStatus()
 
         LOGGER.debug(
-            "Stack %s provider status: %s",
+            "%s:provider status: %s",
             provider.get_stack_name(provider_stack),
             provider.get_stack_status(provider_stack),
         )
@@ -62,7 +62,7 @@ class Action(BaseAction):
             return DESTROYED_STATUS
         if provider.is_stack_in_progress(provider_stack):
             return DESTROYING_STATUS
-        LOGGER.debug("Destroying stack: %s", stack.fqn)
+        LOGGER.debug("%s:destroying stack", stack.fqn)
         provider.destroy_stack(provider_stack)
         return DESTROYING_STATUS
 
@@ -81,7 +81,7 @@ class Action(BaseAction):
         plan = self._generate_plan(tail=kwargs.get('tail'), reverse=True,
                                    include_persistent_graph=True)
         if not plan.keys():
-            LOGGER.warning('WARNING: No stacks detected (error in config?)')
+            LOGGER.warning('no stacks detected (error in config?)')
         if kwargs.get('force', False):
             # need to generate a new plan to log since the outline sets the
             # steps to COMPLETE in order to log them

--- a/runway/cfngin/actions/destroy.py
+++ b/runway/cfngin/actions/destroy.py
@@ -28,6 +28,7 @@ class Action(BaseAction):
     """
 
     DESCRIPTION = 'Destroy stacks'
+    NAME = 'destroy'
 
     @property
     def _stack_action(self):

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -183,7 +183,7 @@ class Action(build.Action):
             )
             stack.set_outputs(outputs)
         except exceptions.StackDidNotChange:
-            LOGGER.info('No changes: %s', stack.fqn)
+            LOGGER.info('%s:no changes', stack.fqn)
             stack.set_outputs(provider.get_outputs(stack.fqn))
         except exceptions.StackDoesNotExist:
             if self.context.persistent_graph:
@@ -203,9 +203,9 @@ class Action(build.Action):
                                    include_persistent_graph=True)
         plan.outline(logging.DEBUG)
         if plan.keys():
-            LOGGER.info("Diffing stacks: %s", ", ".join(plan.keys()))
+            LOGGER.info("diffing stacks: %s", ", ".join(plan.keys()))
         else:
-            LOGGER.warning('WARNING: No stacks detected (error in config?)')
+            LOGGER.warning('no stacks detected (error in config?)')
         walker = build_walker(kwargs.get('concurrency', 0))
         plan.execute(walker)
 

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -153,6 +153,7 @@ class Action(build.Action):
     """
 
     DESCRIPTION = 'Diff stacks'
+    NAME = 'diff'
 
     @property
     def _stack_action(self):

--- a/runway/cfngin/actions/graph.py
+++ b/runway/cfngin/actions/graph.py
@@ -71,6 +71,7 @@ class Action(BaseAction):
     """Responsible for outputing a graph for the current CFNgin config."""
 
     DESCRIPTION = 'Print graph'
+    NAME = 'graph'
 
     @property
     def _stack_action(self):

--- a/runway/cfngin/actions/info.py
+++ b/runway/cfngin/actions/info.py
@@ -16,16 +16,16 @@ class Action(BaseAction):  # pylint: disable=abstract-method
 
     def run(self, **kwargs):
         """Get information on CloudFormation stacks."""
-        LOGGER.info('Outputs for stacks: %s', self.context.get_fqn())
+        LOGGER.info('outputs for stacks: %s', self.context.get_fqn())
         if not self.context.get_stacks():
-            LOGGER.warning('WARNING: No stacks detected (error in config?)')
+            LOGGER.warning('no stacks detected (error in config?)')
         for stack in self.context.get_stacks():
             provider = self.build_provider(stack)
 
             try:
                 provider_stack = provider.get_stack(stack.fqn)
             except exceptions.StackDoesNotExist:
-                LOGGER.info('Stack "%s" does not exist.', stack.fqn,)
+                LOGGER.info('%s:stack does not exist', stack.fqn,)
                 continue
 
             LOGGER.info('%s:', stack.fqn)

--- a/runway/cfngin/actions/info.py
+++ b/runway/cfngin/actions/info.py
@@ -14,6 +14,8 @@ class Action(BaseAction):  # pylint: disable=abstract-method
 
     """
 
+    NAME = 'info'
+
     def run(self, **kwargs):
         """Get information on CloudFormation stacks."""
         LOGGER.info('outputs for stacks: %s', self.context.get_fqn())

--- a/runway/cfngin/blueprints/base.py
+++ b/runway/cfngin/blueprints/base.py
@@ -49,14 +49,14 @@ class CFNParameter(object):
             if isinstance(value, acceptable_type):
                 acceptable = True
                 if acceptable_type == bool:
-                    LOGGER.debug("Converting parameter %s boolean '%s' "
-                                 "to string.", name, value)
+                    LOGGER.debug("converting parameter %s boolean '%s' "
+                                 "to string", name, value)
                     value = str(value).lower()
                     break
 
                 if acceptable_type == int:
-                    LOGGER.debug("Converting parameter %s integer '%s' "
-                                 "to string.", name, value)
+                    LOGGER.debug("converting parameter %s integer '%s' "
+                                 "to string", name, value)
                     value = str(value)
                     break
 
@@ -386,7 +386,7 @@ class Blueprint(object):
         parameters = self.get_parameter_definitions()
 
         if not parameters:
-            LOGGER.debug("No parameters defined.")
+            LOGGER.debug("no parameters defined")
             return
 
         for name, attrs in parameters.items():
@@ -467,7 +467,7 @@ class Blueprint(object):
             return
 
         for name, mapping in self.mappings.items():
-            LOGGER.debug("Adding mapping %s.", name)
+            LOGGER.debug("adding mapping %s", name)
             self.template.add_mapping(name, mapping)
 
     def reset_template(self):

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -114,7 +114,7 @@ class CFNgin(object):
                        sys_modules_exclude=['awacs', 'troposphere']):
             for config_name in config_file_names:
                 logger = PrefixAdaptor(os.path.basename(config_name), LOGGER)
-                logger.notice('deploy (in-progress)')
+                logger.notice('deploy (in progress)')
                 with SafeHaven(argv=['stacker', 'build', config_name],
                                sys_modules_exclude=['awacs', 'troposphere']):
                     ctx = self.load(config_name)
@@ -149,7 +149,7 @@ class CFNgin(object):
         with SafeHaven(environ=self.__ctx.env_vars):
             for config_name in config_file_names:
                 logger = PrefixAdaptor(os.path.basename(config_name), LOGGER)
-                logger.notice('destroy (in-progress)')
+                logger.notice('destroy (in progress)')
                 with SafeHaven(argv=['stacker', 'destroy', config_name]):
                     ctx = self.load(config_name)
                     action = destroy.Action(
@@ -205,7 +205,7 @@ class CFNgin(object):
         with SafeHaven(environ=self.__ctx.env_vars):
             for config_name in config_file_names:
                 logger = PrefixAdaptor(os.path.basename(config_name), LOGGER)
-                logger.notice('plan (in-progress)')
+                logger.notice('plan (in progress)')
                 with SafeHaven(argv=['stacker', 'diff', config_name]):
                     ctx = self.load(config_name)
                     action = diff.Action(

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -63,7 +63,7 @@ class CFNgin(object):
         self.recreate_failed = ctx.is_noninteractive
         self.region = ctx.env_region
         self.sys_path = sys_path or os.getcwd()
-        self.tail = ctx.debug
+        self.tail = bool(ctx.env.debug or ctx.env.verbose)
 
         self.parameters.update(self.env_file)
 

--- a/runway/cfngin/commands/stacker/__init__.py
+++ b/runway/cfngin/commands/stacker/__init__.py
@@ -26,7 +26,7 @@ class Stacker(BaseCommand):
 
     DEPRECATION_MSG = ("Runway's Stacker CLI components have been deprecated "
                        "and will be removed in the next major release of "
-                       "Runway.")
+                       "Runway")
 
     def configure(self, options):
         """Configure CLI command."""
@@ -60,9 +60,9 @@ class Stacker(BaseCommand):
 
         super(Stacker, self).configure(options)
         if options.interactive:
-            LOGGER.info("Using interactive AWS provider mode.")
+            LOGGER.info("using interactive AWS provider mode")
         else:
-            LOGGER.info("Using default AWS provider mode")
+            LOGGER.info("using default AWS provider mode")
 
     def add_arguments(self, parser):
         """Add CLI arguments."""

--- a/runway/cfngin/commands/stacker/base.py
+++ b/runway/cfngin/commands/stacker/base.py
@@ -29,7 +29,7 @@ def cancel():
     def cancel_execution(signum, _frame):
         """Cancel execution."""
         signame = SIGNAL_NAMES.get(signum, signum)
-        LOGGER.info("Signal %s received, quitting "
+        LOGGER.info("signal %s received, quitting "
                     "(this can take some time)...", signame)
         cancel_event.set()
 

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -14,6 +14,8 @@ from schematics.types import (BaseType, BooleanType, DictType, ListType,
                               ModelType, StringType)
 from six import text_type
 
+from runway.util import DOC_SITE
+
 from .. import exceptions
 from ..lookups import register_lookup_handler
 from ..util import SourceProcessor, merge_map, yaml_to_ordered_dict
@@ -47,11 +49,10 @@ def render_parse_load(raw_config, environment=None, validate=True):
     if config.namespace is None:
         namespace = environment.get("namespace")
         if namespace:
-            LOGGER.warning("DEPRECATION WARNING: specifying namespace in the "
-                           "environment is deprecated. See "
-                           "https://docs.onica.com/projects/runway/en/"
-                           "release/cfngin/config.html#namespace "
-                           "for more info.")
+            LOGGER.warning('specifying namespace in the environment is '
+                           'deprecated; to learn how to specify it correctly '
+                           'visit %s/page/cfngin/configuration.html#namespace',
+                           DOC_SITE)
             config.namespace = namespace
 
     if validate:
@@ -141,9 +142,9 @@ def load(config):
 
     """
     if config.sys_path:
-        LOGGER.debug("Appending %s to sys.path.", config.sys_path)
+        LOGGER.debug("appending to sys.path: %s", config.sys_path)
         sys.path.append(config.sys_path)
-        LOGGER.debug("sys.path is now %s", sys.path)
+        LOGGER.debug("sys.path: %s", sys.path)
     if config.lookups:
         for key, handler in config.lookups.items():
             register_lookup_handler(key, handler)
@@ -190,7 +191,7 @@ def process_remote_sources(raw_config, environment=None):
         processor.get_package_sources()
         if processor.configs_to_merge:
             for i in processor.configs_to_merge:
-                LOGGER.debug("Merging in remote config \"%s\"", i)
+                LOGGER.debug("merging in remote config: %s", i)
                 remote_config = yaml.safe_load(open(i))
                 config = merge_map(remote_config, config)
             # Call the render again as the package_sources may have merged in
@@ -533,7 +534,7 @@ class Config(Model):
         if not excess_keys:
             return data
 
-        LOGGER.debug('Removing excess keys from config input: %s',
+        LOGGER.debug('removing excess keys from config: %s',
                      excess_keys)
         clean_data = data.copy()
         for key in excess_keys:
@@ -585,9 +586,9 @@ class Config(Model):
         If in use, show deprecation warning.
 
         """
-        msg = ('Use of "stacker_bucket" has been deprecated and will be '
-               'removed after the next major release. Please use '
-               '"cfngin_bucket".')
+        msg = (
+            'stacker_bucket has been deprecated; use cfngin_bucket instead'
+        )
         if value or value == '':
             warnings.warn(msg, DeprecationWarning)
             LOGGER.warning(msg)
@@ -598,9 +599,10 @@ class Config(Model):
         If in use, show deprecation warning.
 
         """
-        msg = ('Use of "stacker_bucket_region" has been deprecated and will '
-               'be removed after the next major release. Please use '
-               '"cfngin_bucket_region".')
+        msg = (
+            'stacker_bucket_region has been deprecated; use '
+            'cfngin_bucket_region instead'
+        )
         if value:
             warnings.warn(msg, DeprecationWarning)
             LOGGER.warning(msg)
@@ -611,9 +613,10 @@ class Config(Model):
         If in use, show deprecation warning.
 
         """
-        msg = ('Use of "stacker_cache_dir" has been deprecated and will '
-               'be removed after the next major release. Please use '
-               '"cfngin_cache_dir".')
+        msg = (
+            'stacker_cache_dir has been deprecated; use '
+            'cfngin_cache_dir instead'
+        )
         if value:
             warnings.warn(msg, DeprecationWarning)
             LOGGER.warning(msg)

--- a/runway/cfngin/hooks/base.py
+++ b/runway/cfngin/hooks/base.py
@@ -8,7 +8,6 @@ from runway.util import MutableMap
 
 from ..actions import build
 from ..exceptions import StackFailed
-from ..plan import COLOR_CODES
 from ..stack import Stack
 from ..status import COMPLETE, FAILED, PENDING, SKIPPED, SUBMITTED
 
@@ -154,11 +153,17 @@ class Hook(object):
                 logged.
 
         """
-        msg = "%s: %s" % (stack.name, status.name)
+        msg = '{}:{}'.format(stack.name, status.name)
         if status.reason:
-            msg += " (%s)" % (status.reason)
-        color_code = COLOR_CODES.get(status.code, 37)
-        LOGGER.info(msg, extra={"color": color_code})
+            msg += " (%s)" % status.reason
+        if status.code == SUBMITTED.code:
+            LOGGER.notice(msg)
+        elif status.code == COMPLETE.code:
+            LOGGER.success(msg)
+        elif status.code == FAILED.code:
+            LOGGER.error(msg)
+        else:
+            LOGGER.info(msg)
 
     def _run_stack_action(self, action, stack=None, wait=None):
         """Run a CFNgin hook modified for use in hooks.
@@ -213,7 +218,7 @@ class Hook(object):
                 # log status changes like rollback
                 self._log_stack(stack, status)
                 last_status = status
-            LOGGER.debug('Waiting for stack to complete...')
+            LOGGER.debug('waiting for stack to complete...')
             status = action.run(stack=stack, status=status)
 
         self._log_stack(stack, status)

--- a/runway/cfngin/hooks/command.py
+++ b/runway/cfngin/hooks/command.py
@@ -98,7 +98,7 @@ def run_command(provider, context, command, capture=False, interactive=False,
         full_env.update(env)
         env = full_env
 
-    LOGGER.info('Running command: %s', command)
+    LOGGER.info('running command: %s', command)
 
     proc = Popen(command, stdin=in_type, stdout=out_err_type,
                  stderr=out_err_type, env=env, **kwargs)
@@ -115,9 +115,9 @@ def run_command(provider, context, command, capture=False, interactive=False,
 
         # Don't print the command line again if we already did earlier
         if LOGGER.isEnabledFor(logging.INFO):
-            LOGGER.warning('Command failed with returncode %d', status)
+            LOGGER.warning('command failed with returncode %d', status)
         else:
-            LOGGER.warning('Command failed with returncode %d: %s', status,
+            LOGGER.warning('command failed with returncode %d: %s', status,
                            command)
 
         return None

--- a/runway/cfngin/hooks/ecs.py
+++ b/runway/cfngin/hooks/ecs.py
@@ -37,7 +37,7 @@ def create_clusters(provider, context, **kwargs):
     try:
         clusters = kwargs["clusters"]
     except KeyError:
-        LOGGER.error("setup_clusters hook missing \"clusters\" argument")
+        LOGGER.error("clusters argument required but not provided")
         return False
 
     if isinstance(clusters, string_types):
@@ -45,7 +45,7 @@ def create_clusters(provider, context, **kwargs):
 
     cluster_info = {}
     for cluster in clusters:
-        LOGGER.debug("Creating ECS cluster: %s", cluster)
+        LOGGER.debug("creating ECS cluster: %s", cluster)
         response = conn.create_cluster(clusterName=cluster)
         cluster_info[response["cluster"]["clusterName"]] = response
     return {"clusters": cluster_info}

--- a/runway/cfngin/hooks/keypair.py
+++ b/runway/cfngin/hooks/keypair.py
@@ -12,7 +12,7 @@ from . import utils
 
 LOGGER = logging.getLogger(__name__)
 
-KEYPAIR_LOG_MESSAGE = "keypair: %s (%s) %s"
+KEYPAIR_LOG_MESSAGE = "keypair %s (%s) %s"
 
 
 def get_existing_key_pair(ec2, keypair_name):
@@ -32,7 +32,7 @@ def get_existing_key_pair(ec2, keypair_name):
             "fingerprint": keypair["KeyFingerprint"],
         }
 
-    LOGGER.info("keypair: \"%s\" not found", keypair_name)
+    LOGGER.info('keypair "%s" not found', keypair_name)
     return None
 
 
@@ -62,7 +62,7 @@ def read_public_key_file(path):
 
         return data.strip()
     except (ValueError, IOError, OSError) as err:
-        LOGGER.error("Failed to read public key file %s: %s", path, str(err))
+        LOGGER.error('failed to read public key file :%s": %s', path, str(err))
         return None
 
 
@@ -91,7 +91,7 @@ def create_key_pair_in_ssm(ec2, ssm, keypair_name, parameter_name,
             kms_key_label = kms_key_id
             kms_args = {"KeyId": kms_key_id}
 
-        LOGGER.info("Storing generated key in SSM parameter \"%s\" "
+        LOGGER.info("storing generated key in SSM parameter \"%s\" "
                     "using KMS key \"%s\"", parameter_name, kms_key_label)
 
         ssm.put_parameter(
@@ -106,7 +106,7 @@ def create_key_pair_in_ssm(ec2, ssm, keypair_name, parameter_name,
         # Erase the key pair if we failed to store it in SSM, since the
         # private key will be lost anyway
 
-        LOGGER.exception("Failed to store generated key in SSM, deleting "
+        LOGGER.exception("failed to store generated key in SSM; deleting "
                          "created key pair as private key will be lost")
         ec2.delete_key_pair(KeyName=keypair_name, DryRun=False)
         return None
@@ -139,7 +139,7 @@ def create_key_pair_local(ec2, keypair_name, dest_dir):
     key_path = os.path.join(dest_dir, file_name)
     if os.path.isfile(key_path):
         # This mimics the old boto2 keypair.save error
-        LOGGER.error("\"%s\" already exists in \"%s\" directory",
+        LOGGER.error("\"%s\" already exists in directory \"%s\"",
                      file_name, dest_dir)
         return None
 
@@ -260,7 +260,7 @@ def ensure_keypair_exists(provider, context, **kwargs):
         elif action == "create":
             keypair = create_key_pair_local(ec2, keypair_name, path)
         else:
-            LOGGER.warning("no action to find keypair, failing")
+            LOGGER.error("no action to find keypair")
 
     if not keypair:
         return False

--- a/runway/cfngin/hooks/route53.py
+++ b/runway/cfngin/hooks/route53.py
@@ -29,7 +29,9 @@ def create_domain(provider, context, **kwargs):
     client = session.client("route53")
     domain = kwargs.get("domain")
     if not domain:
-        LOGGER.error("domain argument or BaseDomain variable not provided.")
+        LOGGER.error(
+            "domain argument or BaseDomain variable required but not provided"
+        )
         return False
     zone_id = create_route53_zone(client, domain)
     return {"domain": domain, "zone_id": zone_id}

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -42,7 +42,7 @@ def handle_hooks(stage, hooks, provider, context):  # pylint: disable=too-many-s
 
     """
     if not hooks:
-        LOGGER.debug("No %s hooks defined.", stage)
+        LOGGER.debug("no %s hooks defined", stage)
         return
 
     hook_paths = []
@@ -52,21 +52,21 @@ def handle_hooks(stage, hooks, provider, context):  # pylint: disable=too-many-s
         except KeyError:
             raise ValueError("%s hook #%d missing path." % (stage, i))
 
-    LOGGER.info("Executing %s hooks: %s", stage, ", ".join(hook_paths))
+    LOGGER.info("executing %s hooks: %s", stage, ", ".join(hook_paths))
     stage = stage.replace('build', 'deploy')  # TODO remove after full rename
     for hook in hooks:
         data_key = hook.data_key
         required = hook.required
 
         if not hook.enabled:
-            LOGGER.debug("hook with method %s is disabled, skipping",
+            LOGGER.debug("hook with method %s is disabled; skipping",
                          hook.path)
             continue
 
         try:
             method = load_object_from_string(hook.path, try_reload=True)
         except (AttributeError, ImportError):
-            LOGGER.exception("Unable to load method at %s:", hook.path)
+            LOGGER.exception("unable to load method at %s", hook.path)
             if required:
                 raise
             continue
@@ -77,12 +77,13 @@ def handle_hooks(stage, hooks, provider, context):  # pylint: disable=too-many-s
                 resolve_variables(args, context, provider)
             except FailedVariableLookup:
                 if 'pre' in stage:
-                    LOGGER.error('Lookups that change the order of '
-                                 'execution, like "output", can only be '
-                                 'used in "post_*" hooks. Please '
-                                 'ensure that the hook being used does '
-                                 'not rely on a stack, hook_data, or '
-                                 'context that does not exist yet.')
+                    LOGGER.error(
+                        'lookups that change the order of execution, like '
+                        '"output", can only be used in "post_*" hooks; '
+                        'please ensure that the hook being used does '
+                        'not rely on a stack, hook_data, or context that '
+                        'does not exist yet'
+                    )
                 raise
             kwargs = {v.name: v.value for v in args}
         else:
@@ -98,24 +99,24 @@ def handle_hooks(stage, hooks, provider, context):  # pylint: disable=too-many-s
                     stage
                 )()
         except Exception:  # pylint: disable=broad-except
-            LOGGER.exception("Method %s threw an exception:", hook.path)
+            LOGGER.exception("method %s threw an exception", hook.path)
             if required:
                 raise
             continue
 
         if not result:
             if required:
-                LOGGER.error("Required hook %s failed. Return value: %s",
+                LOGGER.error("required hook %s failed; return value: %s",
                              hook.path, result)
                 sys.exit(1)
-            LOGGER.warning("Non-required hook %s failed. Return value: %s",
+            LOGGER.warning("non-required hook %s failed; return value: %s",
                            hook.path, result)
         else:
             if isinstance(result, collections.Mapping):
                 if data_key:
-                    LOGGER.debug("Adding result for hook %s to context in "
-                                 "data_key %s.", hook.path, data_key)
+                    LOGGER.debug("adding result for hook %s to context in "
+                                 "data_key %s", hook.path, data_key)
                     context.set_hook_data(data_key, result)
                 else:
-                    LOGGER.debug("Hook %s returned result data, but no data "
-                                 "key set, so ignoring.", hook.path)
+                    LOGGER.debug("hook %s returned result data but no data "
+                                 "key set; ignoring", hook.path)

--- a/runway/cfngin/lookups/handlers/hook_data.py
+++ b/runway/cfngin/lookups/handlers/hook_data.py
@@ -6,7 +6,7 @@ import warnings
 from troposphere import BaseAWSObject
 
 from runway.lookups.handlers.base import LookupHandler
-from runway.util import MutableMap  # abs to support import through shim
+from runway.util import DOC_SITE, MutableMap  # abs to support import through shim
 
 LOGGER = logging.getLogger(__name__)
 TYPE_NAME = "hook_data"
@@ -15,8 +15,11 @@ TYPE_NAME = "hook_data"
 class HookDataLookup(LookupHandler):
     """Hook data lookup."""
 
-    DEPRECATION_MSG = ('Lookup query syntax "<hook_name>::<key>" has been '
-                       'deprecated. Please use the new lookup query syntax.')
+    DEPRECATION_MSG = (
+        'lookup query syntax "<hook_name>::<key>" has been deprecated; to '
+        'learn how to use the new lookup query syntax visit '
+        '{}/page/lookups.html'.format(DOC_SITE)
+    )
 
     @classmethod
     def legacy_parse(cls, value):

--- a/runway/cfngin/lookups/handlers/ssmstore.py
+++ b/runway/cfngin/lookups/handlers/ssmstore.py
@@ -15,8 +15,8 @@ TYPE_NAME = "ssmstore"
 class SsmstoreLookup(LookupHandler):
     """AWS SSM Parameter Store lookup."""
 
-    DEPRECATION_MSG = ('The "ssmstore" lookup has been deprecated. '
-                       'The "ssm" lookup should be used instead.')
+    DEPRECATION_MSG = ('ssmstore lookup has been deprecated; '
+                       'use the ssm lookup instead')
 
     @classmethod
     def handle(cls, value, context=None, provider=None, **kwargs):

--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -1,11 +1,10 @@
 """CFNgin lookup registry."""
 import logging
-import warnings
 
 from six import string_types
 
 from runway.lookups.handlers import ssm
-from runway.util import load_object_from_string
+from runway.util import DOC_SITE, load_object_from_string
 
 from ..exceptions import FailedVariableLookup, UnknownLookupType
 from .handlers import ami, default, dynamodb, envvar
@@ -13,6 +12,7 @@ from .handlers import file as file_handler
 from .handlers import hook_data, kms, output, rxref, split, ssmstore, xref
 
 CFNGIN_LOOKUP_HANDLERS = {}
+LOGGER = logging.getLogger(__name__)
 
 
 def register_lookup_handler(lookup_type, handler_or_path):
@@ -25,21 +25,17 @@ def register_lookup_handler(lookup_type, handler_or_path):
 
     """
     handler = handler_or_path
+    LOGGER.debug('registering CFNgin lookup: %s=%s', lookup_type, handler_or_path)
     if isinstance(handler_or_path, string_types):
         handler = load_object_from_string(handler_or_path)
     CFNGIN_LOOKUP_HANDLERS[lookup_type] = handler
     if not isinstance(handler, type):
         # Hander is a not a new-style handler
-        logger = logging.getLogger(__name__)
-        logger.warning("Registering lookup `%s`: Please upgrade to use the "
-                       "new style of Lookups.", lookup_type)
-        warnings.warn(
-            # For some reason, this does not show up...
-            # Leaving it in anyway
-            "Lookup `%s`: Please upgrade to use the new style of Lookups"
-            "." % lookup_type,
-            DeprecationWarning,
-            stacklevel=2,
+        LOGGER.warning(
+            'lookup "%s" uses a deprecated format; to learn how to write '
+            'lookups visit %s/page/cfngin/lookups.html#writing-a-custom-lookup',
+            lookup_type,
+            DOC_SITE
         )
 
 

--- a/runway/cfngin/plan.py
+++ b/runway/cfngin/plan.py
@@ -6,6 +6,8 @@ import threading
 import time
 import uuid
 
+from runway._logging import LogLevels, PrefixAdaptor
+
 from .dag import DAG, DAGValidationError, walk
 from .exceptions import (CancelExecution, GraphError, PersistentGraphLocked,
                          PlanFailed)
@@ -15,12 +17,6 @@ from .ui import ui
 from .util import merge_map, stack_template_key_name
 
 LOGGER = logging.getLogger(__name__)
-
-COLOR_CODES = {
-    SUBMITTED.code: 33,  # yellow
-    COMPLETE.code: 32,   # green
-    FAILED.code: 31,     # red
-}
 
 
 def json_serial(obj):
@@ -36,20 +32,6 @@ def json_serial(obj):
     if isinstance(obj, set):
         return list(obj)
     raise TypeError
-
-
-def log_step(step):
-    """Construct a log message for a set and log it to the UI.
-
-    Args:
-        step (:class:`Step`): The step to be logged.
-
-    """
-    msg = "%s: %s" % (step, step.status.name)
-    if step.status.reason:
-        msg += " (%s)" % (step.status.reason)
-    color_code = COLOR_CODES.get(step.status.code, 37)
-    ui.info(msg, extra={"color": color_code})
 
 
 def merge_graphs(graph1, graph2):
@@ -79,6 +61,8 @@ class Step(object):
         fn (Optional[Callable]): Function to run to execute the step.
             This function will be ran multiple times until the step is "done".
         last_updated (float): Time when the step was last updated.
+        logger (logging.LoggerAdaptor): Logger for logging messages about
+            the step.
         stack (:class:`runway.cfngin.stack.Stack`): the stack associated with
             this step
         status (:class:`runway.cfngin.status.Status`): The status of step.
@@ -103,6 +87,7 @@ class Step(object):
         self.stack = stack
         self.status = PENDING
         self.last_updated = time.time()
+        self.logger = PrefixAdaptor(self.stack.name, LOGGER)
         self.fn = fn
         self.watch_func = watch_func
 
@@ -256,11 +241,25 @@ class Step(object):
             self.status = status
             self.last_updated = time.time()
             if self.stack.logging:
-                log_step(self)
+                self.log_step()
 
     def complete(self):
         """Shortcut for ``set_status(COMPLETE)``."""
         self.set_status(COMPLETE)
+
+    def log_step(self):
+        """Construct a log message for a set and log it to the UI."""
+        msg = self.status.name
+        if self.status.reason:
+            msg += " (%s)" % self.status.reason
+        if self.status.code == SUBMITTED.code:
+            ui.log(LogLevels.NOTICE, msg, logger=self.logger)
+        elif self.status.code == COMPLETE.code:
+            ui.log(LogLevels.SUCCESS, msg, logger=self.logger)
+        elif self.status.code == FAILED.code:
+            ui.log(LogLevels.ERROR, msg, logger=self.logger)
+        else:
+            ui.info(msg, logger=self.logger)
 
     def skip(self):
         """Shortcut for ``set_status(SKIPPED)``."""

--- a/runway/cfngin/plan.py
+++ b/runway/cfngin/plan.py
@@ -251,7 +251,7 @@ class Step(object):
 
         """
         if status is not self.status:
-            LOGGER.debug("Setting %s state to %s.", self.stack.name,
+            LOGGER.debug("setting %s state to %s...", self.stack.name,
                          status.name)
             self.status = status
             self.last_updated = time.time()
@@ -657,7 +657,7 @@ class Plan(object):
 
         """
         steps = 1
-        LOGGER.log(level, "Plan \"%s\":", self.description)
+        LOGGER.log(level, "plan \"%s\":", self.description)
         for step in self.steps:
             LOGGER.log(
                 level,
@@ -682,7 +682,7 @@ class Plan(object):
                 Provider to use when resolving the blueprints.
 
         """
-        LOGGER.info("Dumping \"%s\"...", self.description)
+        LOGGER.info("dumping \"%s\"...", self.description)
         directory = os.path.expanduser(directory)
         if not os.path.exists(directory):
             os.makedirs(directory)
@@ -701,7 +701,7 @@ class Plan(object):
             if not os.path.exists(blueprint_dir):
                 os.makedirs(blueprint_dir)
 
-            LOGGER.info("Writing stack \"%s\" -> %s", step.name, path)
+            LOGGER.info("writing stack \"%s\" -> %s", step.name, path)
             with open(path, "w") as _file:
                 _file.write(blueprint.rendered)
 
@@ -765,13 +765,13 @@ class Plan(object):
                                             'cloudformation'))):
                 if step.fn.__name__ == '_destroy_stack':
                     self.context.persistent_graph.pop(step)
-                    LOGGER.debug("Removed step '%s' from the persistent graph",
+                    LOGGER.debug("removed step '%s' from the persistent graph",
                                  step.name)
                 elif step.fn.__name__ == '_launch_stack':
                     self.context.persistent_graph.add_step_if_not_exists(
                         step, add_dependencies=True, add_dependants=True
                     )
-                    LOGGER.debug("Added step '%s' to the persistent graph",
+                    LOGGER.debug("added step '%s' to the persistent graph",
                                  step.name)
                 else:
                     return result

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -792,14 +792,13 @@ class Provider(BaseProvider):
                 protection.
 
         """
-        LOGGER.debug("attempting to create stack %s:", fqn)
-        LOGGER.debug("    parameters: %s", parameters)
-        LOGGER.debug("    tags: %s", tags)
-        if template.url:
-            LOGGER.debug("    template_url: %s", template.url)
-        else:
-            LOGGER.debug("    no template url; uploading template "
-                         "directly")
+        LOGGER.debug("attempting to create stack %s: %s", fqn, json.dumps({
+            'parameters': parameters,
+            'tags': tags,
+            'template_url': template.url
+        }))
+        if not template.url:
+            LOGGER.debug("no template url; uploading template directly")
         if force_change_set:
             LOGGER.debug("force_change_set set to True; creating stack with "
                          "changeset")
@@ -951,13 +950,13 @@ class Provider(BaseProvider):
                 protection.
 
         """
-        LOGGER.debug("attempting to update stack %s:", fqn)
-        LOGGER.debug("    parameters: %s", parameters)
-        LOGGER.debug("    tags: %s", tags)
-        if template.url:
-            LOGGER.debug("    template_url: %s", template.url)
-        else:
-            LOGGER.debug("    no template url; uploading template directly")
+        LOGGER.debug("attempting to update stack %s: %s", fqn, json.dumps({
+            'parameters': parameters,
+            'tags': tags,
+            'template_url': template.url
+        }))
+        if not template.url:
+            LOGGER.debug("no template url; uploading template directly")
         update_method = self.select_update_method(force_interactive,
                                                   force_change_set)
 

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -12,6 +12,8 @@ import yaml
 from botocore.config import Config
 from six.moves import urllib
 
+from runway.util import DOC_SITE
+
 from ... import exceptions
 from ...actions.diff import DictValue, diff_parameters
 from ...actions.diff import format_params_diff as format_diff
@@ -87,30 +89,28 @@ def get_output_dict(stack):
 def s3_fallback(fqn, template, parameters, tags, method,
                 change_set_name=None, service_role=None):
     """Falling back to legacy stacker S3 bucket region for templates."""
-    LOGGER.warning("DEPRECATION WARNING: Falling back to legacy "
-                   "stacker S3 bucket region for templates. See "
-                   "https://docs.onica.com/projects/runway/en/release/"
-                   "cfngin/config.html#s3-bucket"
-                   " for more information.")
+    LOGGER.warning('falling back to deprecated, legacy stacker S3 bucket '
+                   'region for templates; to learn how to correctly provide an '
+                   's3 bucket, visit %s/page/cfngin/configuration.html#s3-bucket',
+                   DOC_SITE)
     # extra line break on purpose to avoid status updates removing URL
     # from view
     LOGGER.warning("\n")
-    LOGGER.debug("Modifying the S3 TemplateURL to point to "
+    LOGGER.debug("modifying the S3 TemplateURL to point to "
                  "us-east-1 endpoint")
     template_url = template.url
     template_url_parsed = urllib.parse.urlparse(template_url)
     template_url_parsed = template_url_parsed._replace(
         netloc="s3.amazonaws.com")
     template_url = urllib.parse.urlunparse(template_url_parsed)
-    LOGGER.debug("Using template_url: %s", template_url)
+    LOGGER.debug("using template_url: %s", template_url)
     args = generate_cloudformation_args(
         fqn, parameters, tags, template,
         service_role=service_role,
         change_set_name=change_set_name
     )
 
-    response = method(**args)
-    return response
+    return method(**args)
 
 
 def get_change_set_name():
@@ -323,7 +323,7 @@ def wait_till_change_set_complete(cfn_client, change_set_id, try_count=25,
             break
         if sleep_time == max_sleep:
             LOGGER.debug(
-                "Still waiting on changeset for another %s seconds",
+                "waiting on changeset for another %s seconds",
                 sleep_time
             )
         time.sleep(sleep_time)
@@ -338,7 +338,7 @@ def wait_till_change_set_complete(cfn_client, change_set_id, try_count=25,
 def create_change_set(cfn_client, fqn, template, parameters, tags,
                       change_set_type='UPDATE', service_role=None):
     """Create CloudFormation change set."""
-    LOGGER.debug("Attempting to create change set of type %s for stack: %s.",
+    LOGGER.debug("attempting to create change set of type %s for stack: %s",
                  change_set_type,
                  fqn)
     args = generate_cloudformation_args(
@@ -369,16 +369,16 @@ def create_change_set(cfn_client, fqn, template, parameters, tags,
         if ("didn't contain changes" in response["StatusReason"] or
                 "No updates are to be performed" in response["StatusReason"]):
             LOGGER.debug(
-                "Stack %s did not change, not updating and removing "
-                "changeset.",
+                "%s:stack did not change; not updating and removing "
+                "changeset",
                 fqn,
             )
             cfn_client.delete_change_set(ChangeSetName=change_set_id)
             raise exceptions.StackDidNotChange()
         LOGGER.warning(
-            "Got strange status, '%s' for changeset '%s'. Not deleting for "
+            "got strange status, '%s' for changeset '%s'; not deleting for "
             "further investigation - you will need to delete the changeset "
-            "manually.",
+            "manually",
             status, change_set_id
         )
         raise exceptions.UnhandledChangeSetStatus(
@@ -492,7 +492,7 @@ def generate_stack_policy_args(stack_policy=None):
     """
     args = {}
     if stack_policy:
-        LOGGER.debug("Stack has a stack policy")
+        LOGGER.debug("stack has a stack policy")
         if stack_policy.url:
             # CFNgin currently does not support uploading stack policies to
             # S3, so this will never get hit (unless your implementing S3
@@ -524,8 +524,8 @@ class ProviderBuilder(object):  # pylint: disable=too-few-public-methods
                 # assume provider is in provider dictionary.
                 provider = self.providers[key]
             except KeyError:
-                LOGGER.debug('Missed memorized lookup (%s), creating new AWS '
-                             'Provider.', key)
+                LOGGER.debug('missed memorized lookup (%s); creating new AWS '
+                             'provider', key)
                 if not region:
                     region = self.region
                 # memoize the result for later.
@@ -661,7 +661,7 @@ class Provider(BaseProvider):
 
         log_func = log_func or _log_func
 
-        LOGGER.info("Tailing stack: %s", stack.fqn)
+        LOGGER.info("%s:tailing stack...", stack.fqn)
 
         attempts = 0
         while True:
@@ -762,11 +762,11 @@ class Provider(BaseProvider):
         approval = kwargs.pop('approval', None)
         force_interactive = kwargs.pop('force_interactive', False)
         fqn = self.get_stack_name(stack)
-        LOGGER.debug("Attempting to delete stack %s", fqn)
+        LOGGER.debug("%s:attempting to delete stack", fqn)
 
         if action == 'build':
-            LOGGER.info('%s was removed from the Stacker config file '
-                        'so it is being destroyed.', fqn)
+            LOGGER.info('%s:removed from the CFNgin config file; '
+                        'it is being destroyed', fqn)
 
         destroy_method = self.select_destroy_method(force_interactive)
         return destroy_method(fqn=fqn, action=action,
@@ -792,17 +792,17 @@ class Provider(BaseProvider):
                 protection.
 
         """
-        LOGGER.debug("Attempting to create stack %s:.", fqn)
+        LOGGER.debug("attempting to create stack %s:", fqn)
         LOGGER.debug("    parameters: %s", parameters)
         LOGGER.debug("    tags: %s", tags)
         if template.url:
             LOGGER.debug("    template_url: %s", template.url)
         else:
-            LOGGER.debug("    no template url, uploading template "
-                         "directly.")
+            LOGGER.debug("    no template url; uploading template "
+                         "directly")
         if force_change_set:
-            LOGGER.debug("force_change_set set to True, creating stack with "
-                         "changeset.")
+            LOGGER.debug("force_change_set set to True; creating stack with "
+                         "changeset")
             _changes, change_set_id = create_change_set(
                 self.cloudformation, fqn, template, parameters, tags,
                 'CREATE', service_role=self.service_role, **kwargs
@@ -916,7 +916,7 @@ class Provider(BaseProvider):
 
             ask_for_approval(include_verbose=False, fqn=stack_name)
 
-        LOGGER.warning('Destroying stack \"%s\" for re-creation', stack_name)
+        LOGGER.warning('%s:destroying stack for re-creation', stack_name)
         self.destroy_stack(stack, approval='y')
 
         return False
@@ -951,13 +951,13 @@ class Provider(BaseProvider):
                 protection.
 
         """
-        LOGGER.debug("Attempting to update stack %s:", fqn)
+        LOGGER.debug("attempting to update stack %s:", fqn)
         LOGGER.debug("    parameters: %s", parameters)
         LOGGER.debug("    tags: %s", tags)
         if template.url:
             LOGGER.debug("    template_url: %s", template.url)
         else:
-            LOGGER.debug("    no template url, uploading template directly.")
+            LOGGER.debug("    no template url; uploading template directly")
         update_method = self.select_update_method(force_interactive,
                                                   force_change_set)
 
@@ -980,7 +980,7 @@ class Provider(BaseProvider):
 
         if stack['EnableTerminationProtection'] != termination_protection:
             LOGGER.debug(
-                'Updating termination protection of stack "%s" to "%s"',
+                '%s:updating termination protection of stack to "%s"',
                 fqn,
                 termination_protection
             )
@@ -1004,7 +1004,7 @@ class Provider(BaseProvider):
         if stack_policy:
             kwargs = generate_stack_policy_args(stack_policy)
             kwargs["StackName"] = fqn
-            LOGGER.debug("Setting stack policy on %s.", fqn)
+            LOGGER.debug("%s:adding stack policy", fqn)
             self.cloudformation.set_stack_policy(**kwargs)
 
     def interactive_destroy_stack(self, fqn, approval=None, **kwargs):
@@ -1015,7 +1015,7 @@ class Provider(BaseProvider):
             approval (Optional[str]): Response to approval prompt.
 
         """
-        LOGGER.debug("Using interactive provider mode for %s.", fqn)
+        LOGGER.debug("%s:using interactive provider mode", fqn)
         action = kwargs.get('action', 'destroy')
 
         approval_options = ['y', 'n']
@@ -1071,7 +1071,7 @@ class Provider(BaseProvider):
                 the tags that should be applied to the Cloudformation stack.
 
         """
-        LOGGER.debug("Using interactive provider mode for %s.", fqn)
+        LOGGER.debug("%s:using interactive provider mode", fqn)
         changes, change_set_id = create_change_set(
             self.cloudformation, fqn, template, parameters, tags,
             'UPDATE', service_role=self.service_role
@@ -1120,7 +1120,7 @@ class Provider(BaseProvider):
             fqn (str): A fully qualified stack name.
 
         """
-        LOGGER.debug("Destroying stack: %s", fqn)
+        LOGGER.debug("%s:destroying stack", fqn)
         args = {"StackName": fqn}
         if self.service_role:
             args["RoleARN"] = self.service_role
@@ -1149,8 +1149,7 @@ class Provider(BaseProvider):
                 that should be applied to the Cloudformation stack.
 
         """
-        LOGGER.debug("Using non-interactive changeset provider mode "
-                     "for %s.", fqn)
+        LOGGER.debug("%s:using non-interactive changeset provider mode", fqn)
         _changes, change_set_id = create_change_set(
             self.cloudformation, fqn, template, parameters, tags,
             'UPDATE', service_role=self.service_role
@@ -1195,7 +1194,7 @@ class Provider(BaseProvider):
                 A template object representing a stack policy.
 
         """
-        LOGGER.debug("Using default provider mode for %s.", fqn)
+        LOGGER.debug("%s:using default provider mode", fqn)
         args = generate_cloudformation_args(
             fqn, parameters, tags, template,
             service_role=self.service_role,
@@ -1206,10 +1205,7 @@ class Provider(BaseProvider):
             self.cloudformation.update_stack(**args)
         except botocore.exceptions.ClientError as err:
             if "No updates are to be performed." in str(err):
-                LOGGER.debug(
-                    "Stack %s did not change, not updating.",
-                    fqn,
-                )
+                LOGGER.debug("%s:stack did not change; not updating", fqn)
                 raise exceptions.StackDidNotChange
             if err.response['Error']['Message'] == ('TemplateURL must '
                                                     'reference a valid '
@@ -1346,15 +1342,15 @@ class Provider(BaseProvider):
             # scope of changes that can invalidate a change
             if resc_change and (resc_change.get('Replacement') == 'True' or
                                 'Properties' in resc_change['Scope']):
-                LOGGER.debug('%s added to invalidation list for %s',
-                             resc_change['LogicalResourceId'], stack.fqn)
+                LOGGER.debug('%s:added to invalidation list: %s',
+                             stack.fqn, resc_change['LogicalResourceId'])
                 refs_to_invalidate.append(resc_change['LogicalResourceId'])
 
         # invalidate cached outputs with inferred changes
         for output, props in old_template.get('Outputs', {}).items():
             if any(r in str(props['Value']) for r in refs_to_invalidate):
                 self._outputs[stack.fqn].pop(output)
-                LOGGER.debug('Removed %s from the outputs of %s',
+                LOGGER.debug('%s:removed from the outputs: %s',
                              output, stack.fqn)
 
         # push values for new + invalidated outputs to outputs
@@ -1375,14 +1371,14 @@ class Provider(BaseProvider):
             try:
                 temp_stack = self.get_stack(stack.fqn)
                 if self.is_stack_in_review(temp_stack):
-                    LOGGER.debug('Removing temporary stack that is created '
+                    LOGGER.debug('removing temporary stack that is created '
                                  'with a ChangeSet of type "CREATE"')
                     # this method is currently only used by one action so
                     # hardcoding should be fine for now.
                     self.destroy_stack(temp_stack, action='diff')
             except exceptions.StackDoesNotExist:
                 # not an issue if the stack was already cleaned up
-                LOGGER.debug('Stack does not exist: %s', stack.fqn)
+                LOGGER.debug('%s:stack does not exist', stack.fqn)
 
         return self.get_outputs(stack.fqn)
 

--- a/runway/cfngin/session_cache.py
+++ b/runway/cfngin/session_cache.py
@@ -12,10 +12,10 @@ from .ui import ui
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PROFILE = None
-DEPRECATION_MSG = ('Use of "get_session" without providing credentials or a '
-                   'profile has been deprecated and will raise an error after '
-                   'the next major release. Please use the "get_session" '
-                   'method of the context object instead.')
+DEPRECATION_MSG = (
+    '"session_cache.get_session" has been deprecated; '
+    'use the "get_session" method of the context object instead'
+)
 # A global credential cache that can be shared among boto3 sessions. This is
 # inherently threadsafe thanks to the GIL:
 # https://docs.python.org/3/glossary.html#term-global-interpreter-lock
@@ -41,10 +41,10 @@ def get_session(region=None,
 
     """
     if profile:
-        LOGGER.debug('Building session using profile "%s" in region "%s"',
+        LOGGER.debug('building session using profile "%s" in region "%s"',
                      profile, region or 'default')
     elif access_key:
-        LOGGER.debug('Building session with Access Key "%s" in region "%s"',
+        LOGGER.debug('building session with Access Key "%s" in region "%s"',
                      access_key, region or 'default')
     elif os.environ.get('AWS_ACCESS_KEY_ID'):
         # TODO raise an error so we don't need to modify os.environ for cfngin

--- a/runway/cfngin/ui.py
+++ b/runway/cfngin/ui.py
@@ -29,17 +29,38 @@ class UI(object):
         """Obtain an exclusive lock on the UI for the current thread."""
         return self._lock.acquire()
 
+    def log(self, lvl, msg, *args, logger=LOGGER, **kwargs):
+        """Log the message if the current thread owns the underlying lock.
+
+        Args:
+            lvl (int): Log level.
+            msg (Union[str, Exception]): String template or exception to use
+                for the log record.
+            logger (Union[logging.LoggerAdaptor, logging.Logger]): Specific
+                logger to log to.
+
+        """
+        self.lock()
+        try:
+            return logger.log(lvl, msg, *args, **kwargs)
+        finally:
+            self.unlock()
+
     def unlock(self, *_args, **_kwargs):
         """Release the lock on the UI."""
         return self._lock.release()
 
-    def info(self, *args, **kwargs):
-        """Log the line if the current thread owns the underlying lock."""
-        self.lock()
-        try:
-            return LOGGER.info(*args, **kwargs)
-        finally:
-            self.unlock()
+    def info(self, msg, *args, logger=LOGGER, **kwargs):
+        """Log the line if the current thread owns the underlying lock.
+
+        Args:
+            msg (Union[str, Exception]): String template or exception to use
+                for the log record.
+            logger (Union[logging.LoggerAdaptor, logging.Logger]): Specific
+                logger to log to.
+
+        """
+        self.log(logging.INFO, msg, logger=logger, *args, **kwargs)
 
     def ask(self, message):
         """Collect input from a user in a multithreaded environment.

--- a/runway/cfngin/ui.py
+++ b/runway/cfngin/ui.py
@@ -29,18 +29,23 @@ class UI(object):
         """Obtain an exclusive lock on the UI for the current thread."""
         return self._lock.acquire()
 
-    def log(self, lvl, msg, *args, logger=LOGGER, **kwargs):
+    # TODO uncomment signature when dropping python 2
+    # def log(self, lvl, msg, *args, logger=LOGGER, **kwargs):
+    def log(self, lvl, msg, *args, **kwargs):
         """Log the message if the current thread owns the underlying lock.
 
         Args:
             lvl (int): Log level.
             msg (Union[str, Exception]): String template or exception to use
                 for the log record.
+
+        Keyword Args:
             logger (Union[logging.LoggerAdaptor, logging.Logger]): Specific
                 logger to log to.
 
         """
         self.lock()
+        logger = kwargs.pop('logger', LOGGER)
         try:
             return logger.log(lvl, msg, *args, **kwargs)
         finally:
@@ -50,17 +55,21 @@ class UI(object):
         """Release the lock on the UI."""
         return self._lock.release()
 
-    def info(self, msg, *args, logger=LOGGER, **kwargs):
+    # TODO uncomment signature when dropping python 2
+    # def info(self, msg, *args, logger=LOGGER, **kwargs):
+    def info(self, msg, *args, **kwargs):
         """Log the line if the current thread owns the underlying lock.
 
         Args:
             msg (Union[str, Exception]): String template or exception to use
                 for the log record.
+
+        Keyword Args:
             logger (Union[logging.LoggerAdaptor, logging.Logger]): Specific
                 logger to log to.
 
         """
-        self.log(logging.INFO, msg, logger=logger, *args, **kwargs)
+        self.log(logging.INFO, msg, *args, **kwargs)
 
     def ask(self, message):
         """Collect input from a user in a multithreaded environment.

--- a/runway/config.py
+++ b/runway/config.py
@@ -11,6 +11,7 @@ from typing import (TYPE_CHECKING, Any, Dict,  # pylint: disable=unused-import
 import yaml
 from six import string_types
 
+from ._logging import PrefixAdaptor
 from .util import MutableMap, cached_property
 from .variables import Variable
 
@@ -111,14 +112,15 @@ class ConfigComponent(MutableMap):
                 populated until processing has begun.
 
         """
+        logger = PrefixAdaptor(self.name, LOGGER) \
+            if hasattr(self, 'name') else LOGGER
         if pre_process:
-            LOGGER.verbose('%s: resolving variables for pre-processing...',
-                           self.name)
+            logger.verbose('resolving variables for pre-processing...')
         else:
-            LOGGER.verbose('%s: resolving variables...', self.name)
+            logger.verbose('resolving variables...')
         for attr in (self.PRE_PROCESS_VARIABLES if pre_process
                      else self.SUPPORTS_VARIABLES):
-            LOGGER.debug('%s: resolving %s...', self.name, attr)
+            logger.debug('resolving %s...', attr)
             getattr(self, '_' + attr).resolve(context, variables=variables)
 
     def __getitem__(self, key):

--- a/runway/context.py
+++ b/runway/context.py
@@ -9,7 +9,7 @@ from .cfngin.session_cache import get_session
 from .core.components import DeployEnvironment
 from .util import cached_property
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class Context(object):
@@ -170,6 +170,7 @@ class Context(object):
             Context: New instance with the same contents.
 
         """
+        LOGGER.debug('creating a copy of Runway context...')
         return self.__class__(command=self.command,
                               deploy_environment=self.env.copy())
 
@@ -193,8 +194,12 @@ class Context(object):
         # save to var so its not calculated multiple times
         creds = self.boto3_credentials
         if profile:
+            LOGGER.verbose('creating AWS session using profile "%s"...',
+                           profile)
             kwargs['profile'] = profile
         elif creds:
+            LOGGER.verbose('creating AWS session using credentials from '
+                           'the environment...')
             kwargs.update({
                 'access_key': creds.get('aws_access_key_id'),
                 'secret_key': creds.get('aws_secret_access_key'),

--- a/runway/core/__init__.py
+++ b/runway/core/__init__.py
@@ -145,7 +145,7 @@ class Runway(object):
         for tst in self.tests:
             tst.resolve(self.ctx, variables=self.variables)
             logger = _PrefixAdaptor(tst.name, LOGGER)
-            logger.notice('running test (in-progress)')
+            logger.notice('running test (in progress)')
             try:
                 handler = _TEST_HANDLERS[tst.type]
             except KeyError:

--- a/runway/core/__init__.py
+++ b/runway/core/__init__.py
@@ -127,9 +127,9 @@ class Runway(object):
     def test(self):
         """Run tests defined in the config."""
         if not self.tests:
-            LOGGER.error('No tests are defined in the Runway config.')
-            LOGGER.error('To learn more about using Runway to run tests, '
-                         'visit %s/page/defining_tests.html.', DOC_SITE)
+            LOGGER.error('no tests defined in runway.yml')
+            LOGGER.error('to learn more about using Runway to run tests, '
+                         'visit %s/page/defining_tests.html', DOC_SITE)
             LOGGER.error('Example test:\n%s', _yaml.dump({
                 'tests': [{'name': 'example-test',
                            'type': 'script',
@@ -169,7 +169,7 @@ class Runway(object):
                     continue  # tests with zero exit code don't indicate failure
                 logger.error('running test (fail)')
                 if tst.required:
-                    logger.error('failed test was required; the remaining '
+                    logger.error('test required; the remaining '
                                  'tests have been skipped')
                     _sys.exit(1)
                 failed_tests.append(tst.name)

--- a/runway/core/components/_deploy_environment.py
+++ b/runway/core/components/_deploy_environment.py
@@ -275,6 +275,21 @@ class DeployEnvironment(object):
             self._update_vars({'DEPLOY_ENVIRONMENT': name})
         return name
 
+    @property
+    def verbose(self):
+        # type: () -> bool
+        """Get verbose setting from the environment."""
+        return 'VERBOSE' in self.vars
+
+    @verbose.setter
+    def verbose(self, value):
+        # type: (Any) -> None
+        """Set the value of VERBOSE."""
+        if value:
+            self._update_vars({'VERBOSE': '1'})
+        else:
+            self.vars.pop('VERBOSE', None)
+
     def copy(self):
         # type: () -> DeployEnvironment
         """Copy the contents of this object into a new instance.

--- a/runway/core/components/_deploy_environment.py
+++ b/runway/core/components/_deploy_environment.py
@@ -311,23 +311,34 @@ class DeployEnvironment(object):
         """Output name to log."""
         name = self.name  # resolve if not already resolved
         if self.name_derived_from == 'explicit':
-            LOGGER.info('Environment "%s" is explicitly defined in the environment.',
-                        name)
-            LOGGER.info('If this is not correct, update '
-                        'the value or unset it to fall back to the name of '
-                        'the current git branch or parent directory.')
+            LOGGER.info(
+                'deploy environment "%s" is explicitly defined in the environment',
+                name
+            )
+            LOGGER.info(
+                'if not correct, update the value or unset it to fall back '
+                'to the name of the current git branch or parent directory'
+            )
         elif self.name_derived_from == 'branch':
-            LOGGER.info('Environment "%s" was determined from the current git branch.',
-                        name)
-            LOGGER.info('If this is not the environment name, update the '
-                        'branch name or set an override via the '
-                        'DEPLOY_ENVIRONMENT environment variable.')
+            LOGGER.info(
+                'deploy environment "%s" was determined from the current '
+                'git branch',
+                name
+            )
+            LOGGER.info(
+                'if not correct, update the branch name or set an override '
+                'via the DEPLOY_ENVIRONMENT environment variable'
+            )
         elif self.name_derived_from == 'directory':
-            LOGGER.info('Environment "%s" was determined from the current directory.',
-                        name)
-            LOGGER.info('If this is not the environment name, update the '
-                        'directory name or set an override via the '
-                        'DEPLOY_ENVIRONMENT environment variable.')
+            LOGGER.info(
+                'deploy environment "%s" was determined from the current '
+                'directory',
+                name
+            )
+            LOGGER.info(
+                'if not correct, update the directory name or set an '
+                'override via the DEPLOY_ENVIRONMENT environment variable'
+            )
 
     def _parse_branch_name(self):
         # type: () -> str

--- a/runway/core/components/_deploy_environment.py
+++ b/runway/core/components/_deploy_environment.py
@@ -1,4 +1,5 @@
 """Runway deploy environment object."""
+import json
 import logging
 # needed for python2 cpu_count, can be replace with python3 os.cpu_count()
 import multiprocessing
@@ -72,7 +73,7 @@ class DeployEnvironment(object):
     def aws_profile(self, profile_name):
         # type: (str) -> None
         """Set AWS profile in the environment."""
-        self.vars['AWS_PROFILE'] = profile_name
+        self._update_vars({'AWS_PROFILE': profile_name})
 
     @property
     def aws_region(self):
@@ -84,7 +85,7 @@ class DeployEnvironment(object):
     def aws_region(self, region):
         # type: (str) -> None
         """Set AWS region environment variables."""
-        self.vars.update({'AWS_DEFAULT_REGION': region, 'AWS_REGION': region})
+        self._update_vars({'AWS_DEFAULT_REGION': region, 'AWS_REGION': region})
 
     @cached_property
     def branch_name(self):
@@ -126,7 +127,7 @@ class DeployEnvironment(object):
         # type: (Any) -> None
         """Set the value of CI."""
         if value:
-            self.vars['CI'] = '1'
+            self._update_vars({'CI': '1'})
         else:
             self.vars.pop('CI', None)
 
@@ -141,7 +142,7 @@ class DeployEnvironment(object):
         # type: (Any) -> None
         """Set the value of DEBUG."""
         if value:
-            self.vars['DEBUG'] = '1'
+            self._update_vars({'DEBUG': '1'})
         else:
             self.vars.pop('DEBUG', None)
 
@@ -189,7 +190,7 @@ class DeployEnvironment(object):
     def max_concurrent_cfngin_stacks(self, value):
         # type: (Union[int, str]) -> None
         """Set RUNWAY_MAX_CONCURRENT_CFNGIN_STACKS."""
-        self.vars['RUNWAY_MAX_CONCURRENT_CFNGIN_STACKS'] = value
+        self._update_vars({'RUNWAY_MAX_CONCURRENT_CFNGIN_STACKS': value})
 
     @property
     def max_concurrent_modules(self):
@@ -220,7 +221,7 @@ class DeployEnvironment(object):
     def max_concurrent_modules(self, value):
         # type: (Union[int, str])-> None
         """Set RUNWAY_MAX_CONCURRENT_MODULES."""
-        self.vars['RUNWAY_MAX_CONCURRENT_MODULES'] = value
+        self._update_vars({'RUNWAY_MAX_CONCURRENT_MODULES': value})
 
     @property
     def max_concurrent_regions(self):
@@ -251,7 +252,7 @@ class DeployEnvironment(object):
     def max_concurrent_regions(self, value):
         # type: (Union[int, str]) -> None
         """Set RUNWAY_MAX_CONCURRENT_REGIONS."""
-        self.vars['RUNWAY_MAX_CONCURRENT_REGIONS'] = value
+        self._update_vars({'RUNWAY_MAX_CONCURRENT_REGIONS': value})
 
     @cached_property
     def name(self):
@@ -264,9 +265,14 @@ class DeployEnvironment(object):
             name = self._parse_branch_name()
         else:
             self.name_derived_from = 'directory'
-            name = self.root_dir.name[4:] \
-                if self.root_dir.name.startswith('ENV-') else self.root_dir.name
-        self.vars['DEPLOY_ENVIRONMENT'] = name
+            if self.root_dir.name.startswith('ENV-'):
+                LOGGER.verbose('stripped "ENV-" from the directory name "%s"',
+                               self.root_dir.name)
+                name = self.root_dir.name[4:]
+            else:
+                name = self.root_dir.name
+        if self.vars.get('DEPLOY_ENVIRONMENT') != name:
+            self._update_vars({'DEPLOY_ENVIRONMENT': name})
         return name
 
     def copy(self):
@@ -277,6 +283,7 @@ class DeployEnvironment(object):
             DeployEnvironment: New instance with the same contents.
 
         """
+        LOGGER.debug('creating a copy of the deploy environment...')
         obj = self.__class__(environ=self.vars.copy(),
                              explicit_name=self.name,
                              ignore_git_branch=self._ignore_git_branch,
@@ -288,7 +295,6 @@ class DeployEnvironment(object):
         # type: () -> None
         """Output name to log."""
         name = self.name  # resolve if not already resolved
-        LOGGER.info('')
         if self.name_derived_from == 'explicit':
             LOGGER.info('Environment "%s" is explicitly defined in the environment.',
                         name)
@@ -307,16 +313,16 @@ class DeployEnvironment(object):
             LOGGER.info('If this is not the environment name, update the '
                         'directory name or set an override via the '
                         'DEPLOY_ENVIRONMENT environment variable.')
-        LOGGER.info('')
 
     def _parse_branch_name(self):
         # type: () -> str
         """Parse branch name for use as deploy environment name."""
         if self.branch_name.startswith('ENV-'):
+            LOGGER.verbose('stripped "ENV-" from the branch name "%s"',
+                           self.branch_name)
             return self.branch_name[4:]
         if self.branch_name == 'master':
-            LOGGER.info('Translating git branch "master" to environment '
-                        '"common"')
+            LOGGER.verbose('translated branch name "master" to "common"')
             return 'common'
         if not self.ci:
             LOGGER.warning('Found unexpected branch name "%s"',
@@ -327,3 +333,15 @@ class DeployEnvironment(object):
                 self.name_derived_from = 'explicit'
             return result
         return self.branch_name
+
+    def _update_vars(self, env_vars):
+        # type: (Dict[str, str]) -> None
+        """Update vars and log the change.
+
+        Args:
+            env_vars (Dict[str, str]): Dict to update self.vars with.
+
+        """
+        self.vars.update(env_vars)
+        LOGGER.verbose('updated environment variables: %s',
+                       json.dumps(env_vars))

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -6,6 +6,7 @@ from typing import (TYPE_CHECKING, Any, Dict, List,  # noqa pylint: disable=W
 
 import six
 
+from ..._logging import PrefixAdaptor
 from ...cfngin.exceptions import UnresolvedVariable
 from ...config import FutureDefinition, VariablesDefinition
 from ...util import (cached_property, merge_dicts,
@@ -50,6 +51,7 @@ class Deployment(object):
         self.definition = definition
         self.ctx = context
         self.name = self.definition.name
+        self.log = PrefixAdaptor(self.name, LOGGER)
         self.__merge_env_vars()
 
     @property
@@ -96,8 +98,8 @@ class Deployment(object):
         """
         assume_role = self.definition.assume_role
         if not assume_role:
-            LOGGER.debug('assume_role not configured for deployment: %s',
-                         self.name)
+            self.log.debug('assume_role not configured for deployment: %s',
+                           self.name)
             return {}
         if isinstance(assume_role, dict):
             top_level = {
@@ -106,25 +108,25 @@ class Deployment(object):
                 'session_name': assume_role.get('session_name')
             }
             if assume_role.get('arn'):
-                LOGGER.debug('role found in the top level dict: %s',
-                             assume_role['arn'])
+                self.log.debug('role found in the top level dict: %s',
+                               assume_role['arn'])
                 return dict(role_arn=assume_role['arn'],
                             duration_seconds=assume_role.get('duration'),
                             **top_level)
             if assume_role.get(self.ctx.env.name):
                 env_assume_role = assume_role[self.ctx.env.name]
                 if isinstance(env_assume_role, dict):
-                    LOGGER.debug('role found in deploy environment dict: %s',
-                                 env_assume_role['arn'])
+                    self.log.debug('role found in deploy environment dict: %s',
+                                   env_assume_role['arn'])
                     return dict(role_arn=env_assume_role['arn'],
                                 duration_seconds=env_assume_role.get('duration'),
                                 **top_level)
-                LOGGER.debug('role found for environment: %s', env_assume_role)
+                self.log.debug('role found for environment: %s', env_assume_role)
                 return dict(role_arn=env_assume_role, **top_level)
-            LOGGER.info('Skipping iam:AssumeRole; no role found for deploy '
-                        'environment "%s"...', self.ctx.env.name)
+            self.log.info('skipping iam:AssumeRole; no role found for deploy '
+                          'environment "%s"...', self.ctx.env.name)
             return {}
-        LOGGER.debug('role found: %s', assume_role)
+        self.log.debug('role found: %s', assume_role)
         return {'role_arn': assume_role,
                 'revert_on_exit': False}
 
@@ -161,9 +163,8 @@ class Deployment(object):
         High level method for running a deployment.
 
         """
-        LOGGER.debug('attempting to deploy "%s" to region(s): %s',
-                     self.ctx.env.name,
-                     ', '.join(self.regions))
+        self.log.verbose('attempting to deploy to region(s): %s',
+                         ', '.join(self.regions))
         if self.use_async:
             return self.__async('deploy')
         return self.__sync('deploy')
@@ -175,9 +176,8 @@ class Deployment(object):
         High level method for running a deployment.
 
         """
-        LOGGER.debug('attempting to destroy "%s" in regions(s): %s',
-                     self.ctx.env.name,
-                     ', '.join(self.regions))
+        self.log.verbose('attempting to destroy in regions(s): %s',
+                         ', '.join(self.regions))
         if self.use_async:
             return self.__async('destroy')
         return self.__sync('destroy')
@@ -189,13 +189,11 @@ class Deployment(object):
         High level method for running a deployment.
 
         """
-        LOGGER.debug('attempting to plan for the next deploy of "%s" to'
-                     ' region(s): %s',
-                     self.ctx.env.name,
-                     ', '.join(self.regions))
+        self.log.verbose('attempting to plan for the next deploy to'
+                         ' region(s): %s', ', '.join(self.regions))
         if self.use_async:
-            LOGGER.info('Processing of regions will be done in parallel '
-                        'during deploy/destroy.')
+            self.log.notice('processing of regions will be done in parallel '
+                            'during deploy/destroy.')
         return self.__sync('plan')
 
     def run(self, action, region):
@@ -235,31 +233,33 @@ class Deployment(object):
         account = aws.AccountDetails(self.ctx)
         if self.account_id_config:
             if self.account_id_config != account.id:
-                LOGGER.error('Current AWS account "%s" does not match '
-                             'required account "%s" in Runway config.',
-                             account.id,
-                             self.account_id_config)
+                self.log.error('current AWS account "%s" does not match '
+                               'required account "%s" in Runway config.',
+                               account.id,
+                               self.account_id_config)
                 sys.exit(1)
-            LOGGER.info('Verified current AWS account matches required '
-                        'account id "%s".', self.account_id_config)
+            self.log.info('verified current AWS account matches required '
+                          'account id "%s".', self.account_id_config)
         if self.account_alias_config:
             if self.account_alias_config not in account.aliases:
-                LOGGER.error('Current AWS account aliases "%s" do not match '
-                             'required account alias "%s" in Runway config.',
-                             ','.join(account.aliases),
-                             self.account_alias_config)
+                self.log.error('current AWS account aliases "%s" do not match '
+                               'required account alias "%s" in Runway config.',
+                               ','.join(account.aliases),
+                               self.account_alias_config)
                 sys.exit(1)
-            LOGGER.info('Verified current AWS account alias matches required '
-                        'alias "%s".',
-                        self.account_alias_config)
+            self.log.info('verified current AWS account alias matches '
+                          'required alias "%s".', self.account_alias_config)
 
     def __merge_env_vars(self):
         # type: () -> None
         """Merge defined env_vars into context.env_vars."""
         if self.env_vars_config:
-            LOGGER.info('OS environment variable overrides being applied '
-                        'this deployment: %s', str(self.env_vars_config))
-        self.ctx.env.vars = merge_dicts(self.ctx.env.vars, self.env_vars_config)
+            self.log.verbose('environment variable overrides are being '
+                             'applied to this deployment')
+            self.log.debug('environment variable overrides: %s',
+                           self.env_vars_config)
+            self.ctx.env.vars = merge_dicts(self.ctx.env.vars,
+                                            self.env_vars_config)
 
     def __async(self, action):
         # type: (str) -> None
@@ -269,8 +269,8 @@ class Deployment(object):
             action (str): Name of action to run.
 
         """
-        LOGGER.info('Processing regions in parallel... '
-                    '(output will be interwoven)')
+        self.log.info('processing regions in parallel... '
+                      '(output will be interwoven)')
         executor = concurrent.futures.ProcessPoolExecutor(
             max_workers=self.ctx.env.max_concurrent_regions
         )
@@ -288,11 +288,9 @@ class Deployment(object):
             action (str): Name of action to run.
 
         """
-        LOGGER.info('Processing regions sequentially...')
+        self.log.info('processing regions sequentially...')
         for region in self.regions:
-            LOGGER.info("")
-            LOGGER.info('====== Processing region %s ======',
-                        region)
+            self.log.verbose('processing AWS region: %s', region)
             self.run(action, region)
 
     @classmethod
@@ -316,21 +314,23 @@ class Deployment(object):
                 resolution.
 
         """
-        for deployment in deployments:
-            LOGGER.debug('Resolving deployment for preprocessing...')
-            deployment.resolve(context, variables=variables, pre_process=True)
+        for definition in deployments:
+            definition.resolve(context, variables=variables, pre_process=True)
+            deployment = cls(context=context,
+                             definition=definition,
+                             future=future,
+                             variables=variables)
             LOGGER.info('')
             LOGGER.info('')
-            LOGGER.info('====== Processing deployment "%s" ======',
-                        deployment.name)
-            if not deployment.modules:
-                LOGGER.warning('No modules found for deployment "%s"',
-                               deployment.name)
+            deployment.log.notice('processing deployment (in-progress)')
+            if not definition.modules:
+                deployment.log.warning('skipping; no modules found in definition')
                 continue
             cls(context=context,
-                definition=deployment,
+                definition=definition,
                 future=future,
                 variables=variables)[action]()
+            deployment.log.success('processing deployment (complete)')
 
     def __getitem__(self, key):
         """Make the object subscriptable.

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -323,7 +323,7 @@ class Deployment(object):
                              variables=variables)
             LOGGER.info('')
             LOGGER.info('')
-            deployment.logger.notice('processing deployment (in-progress)')
+            deployment.logger.notice('processing deployment (in progress)')
             if not definition.modules:
                 deployment.logger.warning(
                     'skipped; no modules found in definition'

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -189,7 +189,7 @@ class Module(object):
 
         """
         LOGGER.info('')
-        self.logger.notice('processing module in %s (in-progress)',
+        self.logger.notice('processing module in %s (in progress)',
                            self.ctx.env.aws_region)
         self.logger.verbose("module payload: %s", json.dumps(self.payload))
         if self.should_skip:

--- a/runway/core/providers/aws/_cli.py
+++ b/runway/core/providers/aws/_cli.py
@@ -20,7 +20,7 @@ def cli(cmd):
         RuntimeError: awscli returned a non-zero exit code.
 
     """
-    LOGGER.debug('passing "%s" to awscli...', ' '.join(cmd))
+    LOGGER.debug('passing command to awscli: %s', ' '.join(cmd))
     with SafeHaven(argv=cmd, environ={'LC_CTYPE': 'en_US.UTF'}):
         exit_code = create_clidriver().main(cmd)
         if exit_code:  # non-zero exit code

--- a/runway/env_mgr/__init__.py
+++ b/runway/env_mgr/__init__.py
@@ -4,7 +4,7 @@ import os
 import platform
 import sys
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 def ensure_versions_dir_exists(env_path):

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -111,8 +111,8 @@ class KBEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         # matching version is already installed
         if os.path.isdir(os.path.join(versions_dir,
                                       version_requested)):
-            LOGGER.info("kubectl version %s already installed; using "
-                        "it...", version_requested)
+            LOGGER.verbose("kubectl version %s already installed; using "
+                           "it...", version_requested)
             return os.path.join(versions_dir,
                                 version_requested,
                                 'kubectl') + self.command_suffix
@@ -120,7 +120,7 @@ class KBEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         LOGGER.info("downloading and using kubectl version %s ...",
                     version_requested)
         download_kb_release(version_requested, versions_dir)
-        LOGGER.info("downloaded kubectl %s successfully", version_requested)
+        LOGGER.verbose("downloaded kubectl %s successfully", version_requested)
         return os.path.join(versions_dir,
                             version_requested,
                             'kubectl') + self.command_suffix

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -180,8 +180,8 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
             # matching version is already installed
             if os.path.isdir(os.path.join(versions_dir,
                                           version_requested)):
-                LOGGER.info("Terraform version %s already installed; using "
-                            "it...", version_requested)
+                LOGGER.verbose("Terraform version %s already installed; using "
+                               "it...", version_requested)
                 return os.path.join(versions_dir,
                                     version_requested,
                                     'terraform') + self.command_suffix
@@ -200,8 +200,8 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         # already been downloaded
         if os.path.isdir(os.path.join(versions_dir,
                                       version)):
-            LOGGER.info("Terraform version %s already installed; using it...",
-                        version)
+            LOGGER.verbose("Terraform version %s already installed; using it...",
+                           version)
             return os.path.join(versions_dir,
                                 version,
                                 'terraform') + self.command_suffix
@@ -209,7 +209,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         LOGGER.info("downloading and using Terraform version %s ...",
                     version)
         download_tf_release(version, versions_dir, self.command_suffix)
-        LOGGER.info("downloaded Terraform %s successfully", version)
+        LOGGER.verbose("downloaded Terraform %s successfully", version)
         return os.path.join(versions_dir,
                             version,
                             'terraform') + self.command_suffix

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -20,7 +20,7 @@ from six.moves.urllib.error import URLError  # pylint: disable=E
 from . import EnvManager, ensure_versions_dir_exists, handle_bin_download_error
 from ..util import get_hash_for_filename, sha256sum
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 TF_VERSION_FILENAME = '.terraform-version'
 
 
@@ -55,6 +55,7 @@ def download_tf_release(version,  # noqa pylint: disable=too-many-locals,too-man
     tf_url = "https://releases.hashicorp.com/terraform/" + version
 
     try:
+        LOGGER.verbose('downloading Terraform from %s...', tf_url)
         for i in [filename, shasums_name]:
             urlretrieve(tf_url + '/' + i,
                         os.path.join(download_dir, i))
@@ -65,7 +66,7 @@ def download_tf_release(version,  # noqa pylint: disable=too-many-locals,too-man
     tf_hash = get_hash_for_filename(filename, os.path.join(download_dir,
                                                            shasums_name))
     if tf_hash != sha256sum(os.path.join(download_dir, filename)):
-        LOGGER.error("Downloaded Terraform %s does not match sha256 %s",
+        LOGGER.error("downloaded Terraform %s does not match sha256 %s",
                      filename, tf_hash)
         sys.exit(1)
 
@@ -114,14 +115,14 @@ def find_min_required(path):
 
     if found_min_required:
         if re.match(r'^!=.+', found_min_required):
-            LOGGER.error('Min required Terraform version is a negation (%s) '
+            LOGGER.error('min required Terraform version is a negation (%s) '
                          '- unable to determine required version',
                          found_min_required)
             sys.exit(1)
         else:
             found_min_required = re.search(r'[0-9]*\.[0-9]*(?:\.[0-9]*)?',
                                            found_min_required).group(0)
-            LOGGER.debug("Detected minimum terraform version is %s",
+            LOGGER.debug("detected minimum Terraform version is %s",
                          found_min_required)
             return found_min_required
     LOGGER.error('Terraform version specified as min-required, but unable to '
@@ -135,9 +136,9 @@ def get_version_requested(path):
     tf_version_path = os.path.join(path,
                                    TF_VERSION_FILENAME)
     if not os.path.isfile(tf_version_path):
-        LOGGER.error("Terraform install attempted and no %s file present to "
-                     "dictate the version. Please create it (e.g.  write "
-                     "\"0.11.13\" (without quotes) to the file and try again",
+        LOGGER.error('Terraform install attempted and no %s file present to '
+                     'dictate the version; please create it. (e.g. write '
+                     '"0.11.13", without quotes, to the file and try again)',
                      TF_VERSION_FILENAME)
         sys.exit(1)
     with open(tf_version_path, 'r') as stream:
@@ -156,7 +157,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         super(TFEnvManager, self).__init__('tfenv', path)
 
     def install(self, version_requested=None):
-        """Ensure terraform is available."""
+        """Ensure Terraform is available."""
         versions_dir = ensure_versions_dir_exists(self.env_dir)
 
         if not version_requested:
@@ -191,7 +192,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
                                include_prerelease_versions)
                            if re.match(regex, i))
         except StopIteration:
-            LOGGER.error("Unable to find a Terraform version matching regex: %s",
+            LOGGER.error("unable to find a Terraform version matching regex: %s",
                          regex)
             sys.exit(1)
 
@@ -205,10 +206,10 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
                                 version,
                                 'terraform') + self.command_suffix
 
-        LOGGER.info("Downloading and using Terraform version %s ...",
+        LOGGER.info("downloading and using Terraform version %s ...",
                     version)
         download_tf_release(version, versions_dir, self.command_suffix)
-        LOGGER.info("Downloaded Terraform %s successfully", version)
+        LOGGER.info("downloaded Terraform %s successfully", version)
         return os.path.join(versions_dir,
                             version,
                             'terraform') + self.command_suffix

--- a/runway/hooks/cleanup_ssm.py
+++ b/runway/hooks/cleanup_ssm.py
@@ -1,25 +1,23 @@
 """CFNgin hook for cleaning up resources prior to CFN stack deletion."""
+# pylint: disable=unused-argument
 # TODO move to runway.cfngin.hooks on next major release
 import logging
-
-from ..cfngin.session_cache import get_session
 
 LOGGER = logging.getLogger(__name__)
 
 
-def delete_param(context, provider, **kwargs):  # noqa pylint: disable=unused-argument
+def delete_param(context, provider, **kwargs):
     """Delete SSM parameter."""
     parameter_name = kwargs.get('parameter_name')
     if not parameter_name:
         raise ValueError('Must specify `parameter_name` for delete_param '
                          'hook.')
 
-    session = get_session(provider.region)
+    session = context.get_session()
     ssm_client = session.client('ssm')
 
     try:
         ssm_client.delete_parameter(Name=parameter_name)
     except ssm_client.exceptions.ParameterNotFound:
-        LOGGER.info("%s parameter appears to have already been deleted...",
-                    parameter_name)
+        LOGGER.info('parameter "%s" does not exist', parameter_name)
     return True

--- a/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
@@ -3,19 +3,18 @@
 Dependency pre-hook responsible for ensuring correct
 callback urls are retrieved or a temporary one is used in it's place.
 """
-
+# pylint: disable=unused-argument
 import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional  # pylint: disable=W
 
-from typing import Any, Dict, Optional  # pylint: disable=unused-import
-
-from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
-from runway.cfngin.context import Context  # noqa pylint: disable=unused-import
-from runway.cfngin.session_cache import get_session
+if TYPE_CHECKING:
+    from ....cfngin.context import Context
+    from ....cfngin.providers.base import BaseProvider
 
 LOGGER = logging.getLogger(__name__)
 
 
-def get(context,  # pylint: disable=unused-argument
+def get(context,
         provider,
         **kwargs
        ):  # noqa: E124
@@ -38,7 +37,7 @@ def get(context,  # pylint: disable=unused-argument
         user_pool_id (str): The ID of the User Pool to check for a client
         stack_name (str) The name of the stack to check against
     """
-    session = get_session(provider.region)
+    session = context.get_session()
     cloudformation_client = session.client('cloudformation')
     cognito_client = session.client('cognito-idp')
 

--- a/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
@@ -8,8 +8,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional  # pylint: disable=W
 
 if TYPE_CHECKING:
-    from ....cfngin.context import Context
-    from ....cfngin.providers.base import BaseProvider
+    from ....cfngin.context import Context  # pylint: disable=W
+    from ....cfngin.providers.base import BaseProvider  # pylint: disable=W
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/hooks/staticsite/auth_at_edge/client_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/client_updater.py
@@ -8,8 +8,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional  # noqa pylint: disable=W
 
 if TYPE_CHECKING:
-    from ....cfngin.providers.base import BaseProvider
-    from ....cfngin.context import Context
+    from ....cfngin.providers.base import BaseProvider  # pylint: disable=W
+    from ....cfngin.context import Context  # pylint: disable=W
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/hooks/staticsite/auth_at_edge/client_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/client_updater.py
@@ -3,13 +3,13 @@
 Responsible for updating the User Pool Client with the generated
 distribution url + callback url paths.
 """
-
+# pylint: disable=unused-argument
 import logging
-from typing import Any, Dict, Optional  # pylint: disable=unused-import
+from typing import TYPE_CHECKING, Any, Dict, Optional  # noqa pylint: disable=W
 
-from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
-from runway.cfngin.context import Context  # noqa pylint: disable=unused-import
-from runway.cfngin.session_cache import get_session
+if TYPE_CHECKING:
+    from ....cfngin.providers.base import BaseProvider
+    from ....cfngin.context import Context
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ def update(context,  # pylint: disable=unused-argument
         oauth_scopes (List[str]): A list of all available validation
             scopes for oauth
     """
-    session = get_session(provider.region)
+    session = context.get_session()
     cognito_client = session.client('cognito-idp')
 
     # Combine alternate domains with main distribution
@@ -66,8 +66,6 @@ def update(context,  # pylint: disable=unused-argument
             UserPoolId=context.hook_data['aae_user_pool_id_retriever']['id'],
         )
         return True
-    except Exception as err:  # pylint: disable=broad-except
-        LOGGER.error('Was not able to update the callback urls on '
-                     'the user pool client')
-        LOGGER.error(err)
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception('unable to update user pool client callback urls')
         return False

--- a/runway/hooks/staticsite/auth_at_edge/domain_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/domain_updater.py
@@ -5,8 +5,8 @@ from typing import (TYPE_CHECKING, Any, Dict,  # pylint: disable=unused-import
                     Optional, Union)
 
 if TYPE_CHECKING:
-    from ....cfngin.context import Context
-    from ....cfngin.providers.base import BaseProvider
+    from ....cfngin.context import Context  # pylint: disable=W
+    from ....cfngin.providers.base import BaseProvider  # pylint: disable=W
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -4,15 +4,14 @@ import logging
 import os
 import re
 import tempfile
-from distutils.dir_util import \
-    copy_tree  # pylint: disable=import-error, no-name-in-module
+from distutils.dir_util import copy_tree  # pylint: disable=E
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Any, Dict, Optional  # pylint: disable=W
 
 from ....cfngin.hooks import aws_lambda
 
 if TYPE_CHECKING:
-    from runway.cfngin.providers.base import BaseProvider
+    from runway.cfngin.providers.base import BaseProvider  # pylint: disable=W
 
 # The functions associated with Auth@Edge
 FUNCTIONS = [

--- a/runway/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -4,13 +4,15 @@ import logging
 import os
 import re
 import tempfile
-from distutils.dir_util import copy_tree  # pylint: disable=import-error, no-name-in-module
+from distutils.dir_util import \
+    copy_tree  # pylint: disable=import-error, no-name-in-module
 from tempfile import mkstemp
-from typing import Any, Dict, Optional  # pylint: disable=unused-import
+from typing import TYPE_CHECKING, Any, Dict, Optional  # pylint: disable=W
 
-from runway.cfngin.hooks import aws_lambda
+from ....cfngin.hooks import aws_lambda
 
-from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
+if TYPE_CHECKING:
+    from runway.cfngin.providers.base import BaseProvider
 
 # The functions associated with Auth@Edge
 FUNCTIONS = [

--- a/runway/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
@@ -4,8 +4,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional  # noqa pylint: disable=W
 
 if TYPE_CHECKING:
-    from ....cfngin.context import Context
-    from ....cfngin.providers.base import BaseProvider
+    from ....cfngin.context import Context  # pylint: disable=W
+    from ....cfngin.providers.base import BaseProvider  # pylint: disable=W
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
@@ -1,16 +1,17 @@
 """Retrieve the ID of the Cognito User Pool."""
+# pylint: disable=unused-argument
 import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional  # noqa pylint: disable=W
 
-from typing import Any, Dict, Optional  # pylint: disable=unused-import
-
-from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
-from runway.cfngin.context import Context  # noqa pylint: disable=unused-import
+if TYPE_CHECKING:
+    from ....cfngin.context import Context
+    from ....cfngin.providers.base import BaseProvider
 
 LOGGER = logging.getLogger(__name__)
 
 
-def get(context,  # pylint: disable=unused-argument
-        provider,  # pylint: disable=unused-argument
+def get(context,
+        provider,
         **kwargs
        ):  # noqa: E124
     # type: (Context, BaseProvider, Optional[Dict[str, Any]]) -> Dict

--- a/runway/hooks/staticsite/build_staticsite.py
+++ b/runway/hooks/staticsite/build_staticsite.py
@@ -110,7 +110,7 @@ def build(context, provider, **kwargs):
         )
     else:
         if options.get('build_steps'):
-            LOGGER.info('build steps (in-progress)')
+            LOGGER.info('build steps (in progress)')
             run_commands(options['build_steps'], options['path'])
             LOGGER.info('build steps (complete)')
         zip_and_upload(build_output, context_dict['artifact_bucket_name'],

--- a/runway/hooks/staticsite/cleanup.py
+++ b/runway/hooks/staticsite/cleanup.py
@@ -1,11 +1,12 @@
 """Replicated Function Remover."""
-import logging
+# pylint: disable=unused-argument
 import json
+import logging
 from typing import Any, Dict, Optional, Union  # pylint: disable=unused-import
 
 from runway.cfngin.context import Context  # pylint: disable=unused-import
-from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
-from runway.cfngin.session_cache import get_session
+from runway.cfngin.providers.base import \
+    BaseProvider  # pylint: disable=unused-import
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ def execute(context,  # type: Context # pylint: disable=unused-argument
         state_machine_arn (str): The ARN of the State Machine to execute
         stack_name (str): The name of the Cleanup stack to delete
     """
-    session = get_session(provider.region)
+    session = context.get_session()
     step_functions_client = session.client('stepfunctions')
 
     try:
@@ -50,7 +51,6 @@ def execute(context,  # type: Context # pylint: disable=unused-argument
             })
         )
         return True
-    except Exception as err:  # pylint: disable=broad-except
-        LOGGER.error('Could not execute cleanup process.')
-        LOGGER.error(err)
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception('could not complete cleanup')
         return False

--- a/runway/hooks/staticsite/cleanup.py
+++ b/runway/hooks/staticsite/cleanup.py
@@ -5,8 +5,7 @@ import logging
 from typing import Any, Dict, Optional, Union  # pylint: disable=unused-import
 
 from runway.cfngin.context import Context  # pylint: disable=unused-import
-from runway.cfngin.providers.base import \
-    BaseProvider  # pylint: disable=unused-import
+from runway.cfngin.providers.base import BaseProvider  # pylint: disable=W
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/hooks/staticsite/upload_staticsite.py
+++ b/runway/hooks/staticsite/upload_staticsite.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 def get_archives_to_prune(archives, hook_data):
     """Return list of keys to delete.
 
-    Keyword Args:
+    Args:
         archives (Dict): The full list of file archives
         hook_data (Dict): CFNgin hook data
 
@@ -38,8 +38,7 @@ def get_archives_to_prune(archives, hook_data):
 def sync(context, provider, **kwargs):
     """Sync static website to S3 bucket.
 
-    Keyword Args:
-
+    Args:
         context (:class:`runway.cfngin.context.Context`): The context
             instance.
         provider (:class:`runway.cfngin.providers.base.BaseProvider`):
@@ -64,7 +63,7 @@ def sync(context, provider, **kwargs):
         invalidate_cache = True
 
     if build_context['deploy_is_current']:
-        LOGGER.info('staticsite: skipping upload; latest version already deployed')
+        LOGGER.info('skipped upload; latest version already deployed')
     else:
         # Using the awscli for s3 syncing is incredibly suboptimal, but on
         # balance it's probably the most stable/efficient option for syncing
@@ -89,7 +88,7 @@ def sync(context, provider, **kwargs):
         distribution = get_distribution_data(context, provider, **kwargs)
         invalidate_distribution(session, **distribution)
 
-    LOGGER.info("staticsite: sync " "complete")
+    LOGGER.info("sync complete")
 
     if not build_context['deploy_is_current']:
         update_ssm_hash(context, session)
@@ -102,7 +101,7 @@ def sync(context, provider, **kwargs):
 def display_static_website_url(website_url_handle, provider, context):
     """Based on the url handle display the static website url.
 
-    Keyword Args:
+    Args:
         website_url_handle (str): the Output handle for the website url
         provider (:class:`runway.cfngin.providers.base.BaseProvider`):
             The provider instance.
@@ -118,7 +117,7 @@ def display_static_website_url(website_url_handle, provider, context):
 def update_ssm_hash(context, session):
     """Update the SSM hash with the new tracking data.
 
-    Keyword Args:
+    Args:
         context (:class:`runway.cfngin.context.Context`): context instance
         session (:class:`runway.cfngin.session.Session`): CFNgin session
 
@@ -129,7 +128,7 @@ def update_ssm_hash(context, session):
         hash_param = build_context['hash_tracking_parameter']
         hash_value = build_context['hash']
 
-        LOGGER.info("staticsite: updating environment SSM parameter %s with hash %s",
+        LOGGER.info("updating SSM parameter %s with hash %s",
                     hash_param,
                     hash_value)
 
@@ -142,14 +141,14 @@ def update_ssm_hash(context, session):
 def get_distribution_data(context, provider, **kwargs):
     """Retrieve information about the distribution.
 
-    Keyword Args:
+    Args:
         context (:class:`runway.cfngin.context.Context`): The context
             instance.
         provider (:class:`runway.cfngin.providers.base.BaseProvider`):
             The provider instance
 
     """
-    LOGGER.info("Retrieved distribution data")
+    LOGGER.verbose("retrieved distribution data")
     return {
         'identifier': OutputLookup.handle(
             kwargs.get('distributionid_output_lookup'),
@@ -168,14 +167,14 @@ def get_distribution_data(context, provider, **kwargs):
 def invalidate_distribution(session, identifier='', path='', domain='', **_):
     """Invalidate the current distribution.
 
-    Keyword Args:
-        session (Session): The current CFNgin session
-        identifier (string): The distribution id
-        path (string): The distribution path
-        domain (string): The distribution domain
+    Args:
+        session (Session): The current CFNgin session.
+        identifier (string): The distribution id.
+        path (string): The distribution path.
+        domain (string): The distribution domain.
 
     """
-    LOGGER.info("staticsite: Invalidating CF distribution")
+    LOGGER.info("invalidating CloudFront distribution: %s", identifier)
     cf_client = session.client('cloudfront')
     cf_client.create_invalidation(
         DistributionId=identifier,
@@ -186,21 +185,21 @@ def invalidate_distribution(session, identifier='', path='', domain='', **_):
             'CallerReference': str(time.time())}
     )
 
-    LOGGER.info("staticsite: CF invalidation of %s (domain %s) " "complete", identifier, domain)
+    LOGGER.info("CloudFront invalidation complete")
     return True
 
 
 def prune_archives(context, session):
     """Prune the archives from the bucket.
 
-    Keyword Args:
+    Args:
         context (:class:`runway.cfngin.context.Context`): The context
             instance.
         session (:class:`runway.cfngin.session.Session`): The CFNgin
             session.
 
     """
-    LOGGER.info("staticsite: cleaning up old site archives...")
+    LOGGER.info("cleaning up old site archives...")
     archives = []
     s3_client = session.client('s3')
     list_objects_v2_paginator = s3_client.get_paginator('list_objects_v2')
@@ -231,8 +230,10 @@ def auto_detect_content_type(filename):
 
     Args:
         filename (str): A filename to use to auto detect the content type.
+
     Returns:
-        str: The content type of the file. None if the content type could not be detected.
+        str: The content type of the file. None if the content type
+        could not be detected.
 
     """
     _, ext = os.path.splitext(filename)
@@ -250,10 +251,13 @@ def get_content_type(extra_file):
     """Return the content type of the file.
 
     Args:
-        extra_file (Dict[str, Union[str, Dict[Any]]]): The extra file configuration.
+        extra_file (Dict[str, Union[str, Dict[Any]]]): The extra file
+            configuration.
+
     Returns:
-        str: The content type of the extra file. If 'content_type' is provided then that is
-             returned, otherways it is auto detected based on the name.
+        str: The content type of the extra file. If 'content_type' is
+        provided then that is returned, otherways it is auto detected
+        based on the name.
 
     """
     return extra_file.get(
@@ -265,7 +269,9 @@ def get_content(extra_file):
     """Get serialized content based on content_type.
 
     Args:
-        extra_file (Dict[str, Union[str, Dict[Any]]]): The extra file configuration.
+        extra_file (Dict[str, Union[str, Dict[Any]]]): The extra file
+            configuration.
+
     Returns:
         str: Serialized content based on the content_type.
 
@@ -281,7 +287,9 @@ def get_content(extra_file):
             if content_type == 'text/yaml':
                 return yaml.safe_dump(content)
 
-            raise ValueError('"content_type" must be json or yaml if "content" is not a string')
+            raise ValueError(
+                '"content_type" must be json or yaml if "content" is not a string'
+            )
 
         if not isinstance(content, str):
             raise TypeError('unsupported content: %s' % type(content))
@@ -295,12 +303,13 @@ def calculate_hash_of_extra_files(extra_files):
     Adapted from stacker.hooks.aws_lambda; used according to its license:
     https://github.com/cloudtools/stacker/blob/1.4.0/LICENSE
 
-    All attributes of the extra file object are includeded when hashing:
+    All attributes of the extra file object are included when hashing:
     name, content_type, content, and file data.
 
     Args:
-        extra_files (List[Dict[str, Union[str, Dict[Any]]]]): The list of extra file
-            configurations.
+        extra_files (List[Dict[str, Union[str, Dict[Any]]]]): The list of
+            extra file configurations.
+
     Returns:
         str: The hash of all the files.
 
@@ -314,12 +323,12 @@ def calculate_hash_of_extra_files(extra_files):
             file_hash.update((extra_file['content_type'] + "\0").encode())
 
         if extra_file.get('content'):
-            LOGGER.debug('hashing content %s', extra_file['name'])
+            LOGGER.debug('hashing content: %s', extra_file['name'])
             file_hash.update((extra_file['content'] + "\0").encode())
 
         if extra_file.get('file'):
             with open(extra_file['file'], "rb") as filedes:
-                LOGGER.debug('hashing file %s', extra_file['file'])
+                LOGGER.debug('hashing file: %s', extra_file['file'])
                 for chunk in iter(lambda: filedes.read(4096), ""):  # noqa pylint: disable=cell-var-from-loop
                     if not chunk:
                         break
@@ -335,8 +344,9 @@ def get_ssm_value(session, name):
     Args:
         session (:class:`runway.cfngin.session.Session`): The CFNgin session.
         name (str): The parameter name.
+
     Returns:
-        str: The parameter value
+        str: The parameter value.
 
     """
     ssm_client = session.client('ssm')
@@ -371,17 +381,16 @@ def set_ssm_value(session, name, value, description=''):
 def sync_extra_files(context, bucket, extra_files, **kwargs):
     """Sync static website extra files to S3 bucket.
 
-    Keyword Args:
+    Args:
 
         context (:class:`runway.cfngin.context.Context`): The context
             instance.
         bucket (str): The static site bucket name.
-        extra_files (List[Dict[str, str]]): List of files and file content that should be
-            uploaded.
+        extra_files (List[Dict[str, str]]): List of files and file content
+            that should be uploaded.
 
     """
-    LOGGER.debug('bucket: %s', bucket)
-    LOGGER.debug('extra_files: %s', json.dumps(extra_files))
+    LOGGER.debug('extra_files to sync: %s', json.dumps(extra_files))
 
     if not extra_files:
         return []
@@ -409,7 +418,9 @@ def sync_extra_files(context, bucket, extra_files, **kwargs):
         hash_new = calculate_hash_of_extra_files(extra_files)
 
         if hash_new == hash_old:
-            LOGGER.info("Skipping extra files upload; latest version already deployed")
+            LOGGER.info(
+                "skipped upload of extra files; latest version already deployed"
+            )
             return []
 
     for extra_file in extra_files:
@@ -419,7 +430,7 @@ def sync_extra_files(context, bucket, extra_files, **kwargs):
         source = extra_file.get('file')
 
         if content:
-            LOGGER.info('Uploading extra file: %s', filename)
+            LOGGER.info('uploading extra file: %s', filename)
 
             s3_client.put_object(
                 Bucket=bucket,
@@ -431,7 +442,7 @@ def sync_extra_files(context, bucket, extra_files, **kwargs):
             uploaded.append(filename)
 
         if source:
-            LOGGER.info('Uploading extra file: %s as %s ', source, filename)
+            LOGGER.info('uploading extra file: %s as %s ', source, filename)
 
             extra_args = None
 
@@ -443,7 +454,11 @@ def sync_extra_files(context, bucket, extra_files, **kwargs):
             uploaded.append(filename)
 
     if hash_new:
-        LOGGER.info("Updating extra files SSM parameter %s with hash %s", hash_param, hash_new)
+        LOGGER.info(
+            "updating extra files SSM parameter %s with hash %s",
+            hash_param,
+            hash_new
+        )
         set_ssm_value(session, hash_param, hash_new)
 
     return uploaded

--- a/runway/hooks/staticsite/upload_staticsite.py
+++ b/runway/hooks/staticsite/upload_staticsite.py
@@ -174,7 +174,8 @@ def invalidate_distribution(session, identifier='', path='', domain='', **_):
         domain (string): The distribution domain.
 
     """
-    LOGGER.info("invalidating CloudFront distribution: %s", identifier)
+    LOGGER.info("invalidating CloudFront distribution: %s (%s)",
+                identifier, domain)
     cf_client = session.client('cloudfront')
     cf_client.create_invalidation(
         DistributionId=identifier,

--- a/runway/lookups/handlers/base.py
+++ b/runway/lookups/handlers/base.py
@@ -170,7 +170,7 @@ class LookupHandler(object):
         if transform:
             return cls.transform(value, to_type=transform, **kwargs)
         if isinstance(value, MutableMap):
-            LOGGER.debug('Returning data from MutableMap')
+            LOGGER.debug('returning data from MutableMap')
             return value.data
         return value
 

--- a/runway/lookups/handlers/env.py
+++ b/runway/lookups/handlers/env.py
@@ -35,7 +35,7 @@ limited or no effect:
 
 """
 # pylint: disable=arguments-differ
-from typing import Any, TYPE_CHECKING  # pylint: disable=unused-import
+from typing import TYPE_CHECKING, Any  # pylint: disable=unused-import
 
 from .base import LookupHandler
 

--- a/runway/lookups/handlers/var.py
+++ b/runway/lookups/handlers/var.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from ...context import Context  # noqa: F401 pylint: disable=unused-import
 
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 TYPE_NAME = 'var'
 
 

--- a/runway/lookups/handlers/var.py
+++ b/runway/lookups/handlers/var.py
@@ -33,9 +33,8 @@ limited or no effect:
 
 """
 # pylint: disable=arguments-differ
-from typing import Any, TYPE_CHECKING  # pylint: disable=unused-import
-
 import logging
+from typing import TYPE_CHECKING, Any  # pylint: disable=unused-import
 
 from .base import LookupHandler
 

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -194,7 +194,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
         """Ensure npm is installed and in the current path."""
         if not which('npm'):
             self.logger.error('"npm" not found in path or is not executable; '
-                              'please ensure it is installed correctly.')
+                              'please ensure it is installed correctly')
             sys.exit(1)
 
     def log_npm_command(self, command):

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -27,28 +27,30 @@ def format_npm_command_for_logging(command):
     return ' '.join(command)
 
 
-def generate_node_command(command, command_opts, path):
+def generate_node_command(command, command_opts, path, logger=LOGGER):
     """Return node bin command list for subprocess execution."""
     if which(NPX_BIN):
         # Use npx if available (npm v5.2+)
-        LOGGER.debug("Using npx to invoke %s.", command)
         cmd_list = [NPX_BIN,
                     '-c',
                     "%s %s" % (command, ' '.join(command_opts))]
     else:
-        LOGGER.debug('npx not found; falling back invoking %s shell script '
-                     'directly.', command)
+        logger.debug(
+            'npx not found; falling back to invoking shell script directly'
+        )
         cmd_list = [
             os.path.join(path,
                          'node_modules',
                          '.bin',
                          command)
         ] + command_opts
+    logger.debug('node command: %s', format_npm_command_for_logging(cmd_list))
     return cmd_list
 
 
-def run_module_command(cmd_list, env_vars, exit_on_error=True):
+def run_module_command(cmd_list, env_vars, exit_on_error=True, logger=LOGGER):
     """Shell out to provisioner command."""
+    logger.debug('running command: %s', ' '.join(cmd_list))
     if exit_on_error:
         try:
             subprocess.check_call(cmd_list, env=env_vars)
@@ -74,23 +76,20 @@ def use_npm_ci(path):
     return False
 
 
-def run_npm_install(path, options, context):
+def run_npm_install(path, options, context, logger=LOGGER):
     """Run npm install/ci."""
     # Use npm ci if available (npm v5.7+)
     cmd = [NPM_BIN, '<place-holder>']
     if context.no_color:
         cmd.append('--no-color')
     if options.get('options', {}).get('skip_npm_ci'):
-        LOGGER.info("Skipping npm ci or npm install on %s...",
-                    os.path.basename(path))
+        logger.info("skipped npm ci/npm install")
         return
     if context.env_vars.get('CI') and use_npm_ci(path):
-        LOGGER.info("Running npm ci on %s...",
-                    os.path.basename(path))
+        logger.info("running npm ci...")
         cmd[1] = 'ci'
     else:
-        LOGGER.info("Running npm install on %s...",
-                    os.path.basename(path))
+        logger.info("running npm install...")
         cmd[1] = 'install'
     subprocess.check_call(cmd)
 
@@ -120,6 +119,7 @@ class RunwayModule(object):
 
         """
         self.context = context
+        self.logger = LOGGER
         self.path = str(path)
         self.options = {} if options is None else options
         if isinstance(path, Path):
@@ -193,9 +193,8 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
     def check_for_npm(self):
         """Ensure npm is installed and in the current path."""
         if not which('npm'):
-            LOGGER.error('%s: "npm" not found in path or is not executable; '
-                         'please ensure it is installed correctly.',
-                         self.name)
+            self.logger.error('"npm" not found in path or is not executable; '
+                              'please ensure it is installed correctly.')
             sys.exit(1)
 
     def log_npm_command(self, command):
@@ -205,8 +204,10 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
             command (List[str]): List that will be passed into a subprocess.
 
         """
-        LOGGER.info('%s: Running "%s"', self.name,
-                    format_npm_command_for_logging(command))
+        self.logger.debug(
+            'node command: %s',
+            format_npm_command_for_logging(command)
+        )
 
     def npm_install(self):
         """Run ``npm install``."""
@@ -214,16 +215,13 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
         if self.context.no_color:
             cmd.append('--no-color')
         if self.options.get('skip_npm_ci'):
-            LOGGER.info("%s: Skipping npm ci and npm install...",
-                        self.name)
+            self.logger.info("skipped npm ci/npm install")
             return
         if self.context.is_noninteractive and use_npm_ci(str(self.path)):
-            LOGGER.info("%s: Running npm ci...",
-                        self.name)
+            self.logger.info("running npm ci...")
             cmd[1] = 'ci'
         else:
-            LOGGER.info("%s: Running npm install...",
-                        self.name)
+            self.logger.info("running npm install...")
             cmd[1] = 'install'
         subprocess.check_call(cmd)
 
@@ -235,8 +233,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
 
         """
         if not (self.path / 'package.json').is_file():
-            LOGGER.warning('%s: Module is missing a "package.json"',
-                           self.name)
+            self.logger.debug('module is missing package.json')
             return True
         return False
 

--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -73,7 +73,7 @@ class CloudDevelopmentKit(RunwayModule):
                                     logger=self.logger)
                     if self.options.get('options', {}).get('build_steps',
                                                            []):
-                        self.logger.info('build steps (in-progress)')
+                        self.logger.info('build steps (in progress)')
                         run_commands(
                             commands=self.options.get('options',
                                                       {}).get('build_steps',
@@ -87,7 +87,7 @@ class CloudDevelopmentKit(RunwayModule):
                         cdk_context_opts.extend(['-c', "%s=%s" % (key, val)])
                     cdk_opts.extend(cdk_context_opts)
                     if command == 'diff':
-                        self.logger.info("plan (in-progress)")
+                        self.logger.info("plan (in progress)")
                         for i in get_cdk_stacks(self.path,
                                                 self.context.env.vars,
                                                 cdk_context_opts):
@@ -115,7 +115,7 @@ class CloudDevelopmentKit(RunwayModule):
                                 (['--no-color'] if self.context.no_color else []),
                                 self.path
                             )
-                            self.logger.info('bootstrap (in-progress)')
+                            self.logger.info('bootstrap (in progress)')
                             run_module_command(cmd_list=bootstrap_command,
                                                env_vars=self.context.env.vars,
                                                logger=self.logger)
@@ -128,7 +128,7 @@ class CloudDevelopmentKit(RunwayModule):
                             cdk_opts,
                             self.path
                         )
-                        self.logger.info('%s (in-progress)', command)
+                        self.logger.info('%s (in progress)', command)
                         run_module_command(cmd_list=cdk_command,
                                            env_vars=self.context.env.vars,
                                            logger=self.logger)

--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -134,7 +134,7 @@ class CloudDevelopmentKit(RunwayModule):
                                            logger=self.logger)
                         self.logger.info('%s (complete)', command)
             else:
-                self.logger.info('skipped; package.json with "aws-cdk" as a '
+                self.logger.info('skipped; package.json with "aws-cdk" in '
                                  'devDependencies is required for this module '
                                  'type')
         else:

--- a/runway/module/cloudformation.py
+++ b/runway/module/cloudformation.py
@@ -1,14 +1,30 @@
 """Cloudformation module."""
 import logging
 
+from .._logging import PrefixAdaptor
 from ..cfngin import CFNgin
 from . import RunwayModule
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class CloudFormation(RunwayModule):
     """CloudFormation (Stacker) Runway Module."""
+
+    def __init__(self, context, path, options=None):
+        """Instantiate class.
+
+        Args:
+            context (Context): Runway context object.
+            path (Union[str, Path]): Path to the module.
+            options (Dict[str, Dict[str, Any]]): Everything in the module
+                definition merged with applicable values from the deployment
+                definition.
+
+        """
+        super(CloudFormation, self).__init__(context, path, options)
+        # logger needs to be created here to use the correct logger
+        self.logger = PrefixAdaptor(self.name, LOGGER)
 
     def deploy(self):
         """Run stacker build."""

--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -7,11 +7,12 @@ import sys
 
 import six
 
-from runway.module import RunwayModule, run_module_command
-from runway.env_mgr.kbenv import KBEnvManager
-from runway.util import which
+from .._logging import PrefixAdaptor
+from ..env_mgr.kbenv import KB_VERSION_FILENAME, KBEnvManager
+from ..util import DOC_SITE, which
+from . import RunwayModule, run_module_command
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 def gen_overlay_dirs(environment, region):
@@ -48,19 +49,33 @@ def generate_response(overlay_path, module_path, environment, region):
     """Determine if environment is defined."""
     configfile = os.path.join(overlay_path, 'kustomization.yaml')
     if os.path.isdir(overlay_path) and os.path.isfile(configfile):
-        LOGGER.info("Processing kustomize overlay: %s", configfile)
+        LOGGER.info("processing kustomize overlay: %s", configfile)
         return {'skipped_configs': False}
-    LOGGER.error("No kustomize overlay for this environment/region found -- "
-                 "looking for one of \"%s\"",
-                 ', '.join(
-                     [os.path.join(module_path, 'overlays', i, 'kustomization.yaml')  # noqa
-                      for i in gen_overlay_dirs(environment, region)]
-                 ))
+    LOGGER.error("skipping; kustomize overlay for this environment/region not"
+                 " found -- looking for one of \"%s\"",
+                 ', '.join([os.path.join(module_path, 'overlays', i,
+                                         'kustomization.yaml')
+                            for i in gen_overlay_dirs(environment, region)]))
     return {'skipped_configs': True}
 
 
 class K8s(RunwayModule):
     """Kubectl Runway Module."""
+
+    def __init__(self, context, path, options=None):
+        """Instantiate class.
+
+        Args:
+            context (Context): Runway context object.
+            path (Union[str, Path]): Path to the module.
+            options (Dict[str, Dict[str, Any]]): Everything in the module
+                definition merged with applicable values from the deployment
+                definition.
+
+        """
+        super(K8s, self).__init__(context, path, options)
+        # logger needs to be created here to use the correct logger
+        self.logger = PrefixAdaptor(self.name, LOGGER)
 
     def run_kubectl(self, command='plan'):
         """Run kubectl."""
@@ -69,63 +84,73 @@ class K8s(RunwayModule):
             'overlays',
             get_overlay_dir(os.path.join(self.path,
                                          'overlays'),
-                            self.context.env_name,
-                            self.context.env_region)
+                            self.context.env.name,
+                            self.context.env.aws_region)
         )
         response = generate_response(kustomize_config_path,
                                      self.path,
-                                     self.context.env_name,
-                                     self.context.env_region)
+                                     self.context.env.name,
+                                     self.context.env.aws_region)
         if response['skipped_configs']:
             return response
 
         module_defined_k8s_ver = get_module_defined_k8s_ver(
             self.options.get('options', {}).get('kubectl_version', {}),
-            self.context.env_name
+            self.context.env.name
         )
         if module_defined_k8s_ver:
+            self.logger.debug('using kubectl version from the module definition')
             k8s_bin = KBEnvManager(self.path).install(module_defined_k8s_ver)
         elif os.path.isfile(os.path.join(kustomize_config_path,
-                                         '.kubectl-version')):
+                                         KB_VERSION_FILENAME)):
+            self.logger.debug('using kubectl version from the overlay '
+                              'directory: %s', kustomize_config_path)
             k8s_bin = KBEnvManager(kustomize_config_path).install()
-        elif os.path.isfile(os.path.join(self.path,
-                                         '.kubectl-version')):
+        elif os.path.isfile(os.path.join(self.path, KB_VERSION_FILENAME)):
+            self.logger.debug('using kubectl version from the module '
+                              'directory: %s', self.path)
             k8s_bin = KBEnvManager(self.path).install()
-        elif os.path.isfile(os.path.join(self.context.env_root,
-                                         '.kubectl-version')):
-            k8s_bin = KBEnvManager(self.context.env_root).install()
+        elif (self.context.env.root_dir / KB_VERSION_FILENAME).is_file():
+            file_path = self.context.env.root_dir / KB_VERSION_FILENAME
+            self.logger.debug('using kubectl version from the project\'s root '
+                              'directory: %s', file_path)
+            k8s_bin = KBEnvManager(self.context.env.root_dir).install()
         else:
+            self.logger.debug('kubectl version not specified; checking path')
             if not which('kubectl'):
-                LOGGER.error('kubectl not available (a '
-                             '".kubectl-version" file is not present '
-                             'and "kubectl" not found in path). Fix '
-                             'this by writing a desired kubectl version '
-                             'to your module\'s .kubectl-version file '
-                             'or installing kubectl.')
+                self.logger.error('kubectl not available and a version to '
+                                  'install not specified')
+                self.logger.error('learn how to use Runway to manage '
+                                  'kubectl versions at %s/page/kubernetes/'
+                                  'advanced_features.html#version-management',
+                                  DOC_SITE)
                 sys.exit(1)
             k8s_bin = 'kubectl'
 
         kustomize_cmd = [k8s_bin, 'kustomize', kustomize_config_path]
+        self.logger.debug('running kubectl command: %s',
+                          ' '.join(kustomize_cmd))
         kustomize_yml = subprocess.check_output(kustomize_cmd,
-                                                env=self.context.env_vars)
+                                                env=self.context.env.vars)
         if isinstance(kustomize_yml, bytes):  # python3 returns encoded bytes
             kustomize_yml = kustomize_yml.decode()
         if command == 'plan':
-            LOGGER.info('The following yaml was generated by '
-                        'kubectl:\n\n%s', kustomize_yml)
+            self.logger.info('yaml was generated by kubectl:\n\n%s',
+                             kustomize_yml)
         else:
-            LOGGER.debug('The following yaml was generated by '
-                         'kubectl:\n\n%s', kustomize_yml)
+            self.logger.debug('yaml generated by kubectl:\n\n%s',
+                              kustomize_yml)
         if command in ['apply', 'delete']:
             kubectl_command = [k8s_bin, command]
             if command == 'delete':
                 kubectl_command.append('--ignore-not-found=true')
             kubectl_command.extend(['-k', kustomize_config_path])
 
-            LOGGER.info('Running kubectl %s ("%s")...',
-                        command,
-                        ' '.join(kubectl_command))
-            run_module_command(kubectl_command, self.context.env_vars)
+            self.logger.info('%s (in-progress)', command)
+            self.logger.debug('running kubectl command: %s',
+                              ' '.join(kubectl_command))
+            run_module_command(kubectl_command, self.context.env.vars)
+            self.logger.info('%s (complete)', command)
         return response
 
     def plan(self):

--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -146,7 +146,7 @@ class K8s(RunwayModule):
                 kubectl_command.append('--ignore-not-found=true')
             kubectl_command.extend(['-k', kustomize_config_path])
 
-            self.logger.info('%s (in-progress)', command)
+            self.logger.info('%s (in progress)', command)
             self.logger.debug('running kubectl command: %s',
                               ' '.join(kubectl_command))
             run_module_command(kubectl_command, self.context.env.vars,

--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -51,11 +51,11 @@ def generate_response(overlay_path, module_path, environment, region):
     if os.path.isdir(overlay_path) and os.path.isfile(configfile):
         LOGGER.info("processing kustomize overlay: %s", configfile)
         return {'skipped_configs': False}
-    LOGGER.error("skipping; kustomize overlay for this environment/region not"
-                 " found -- looking for one of \"%s\"",
-                 ', '.join([os.path.join(module_path, 'overlays', i,
-                                         'kustomization.yaml')
-                            for i in gen_overlay_dirs(environment, region)]))
+    LOGGER.info("skipping; kustomize overlay for this environment/region not"
+                " found -- looking for one of: %s",
+                ', '.join([os.path.join(module_path, 'overlays', i,
+                                        'kustomization.yaml')
+                           for i in gen_overlay_dirs(environment, region)]))
     return {'skipped_configs': True}
 
 
@@ -149,7 +149,8 @@ class K8s(RunwayModule):
             self.logger.info('%s (in-progress)', command)
             self.logger.debug('running kubectl command: %s',
                               ' '.join(kubectl_command))
-            run_module_command(kubectl_command, self.context.env.vars)
+            run_module_command(kubectl_command, self.context.env.vars,
+                               logger=self.logger)
             self.logger.info('%s (complete)', command)
         return response
 

--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -51,7 +51,7 @@ def generate_response(overlay_path, module_path, environment, region):
     if os.path.isdir(overlay_path) and os.path.isfile(configfile):
         LOGGER.info("processing kustomize overlay: %s", configfile)
         return {'skipped_configs': False}
-    LOGGER.info("skipping; kustomize overlay for this environment/region not"
+    LOGGER.info("skipped; kustomize overlay for this environment/region not"
                 " found -- looking for one of: %s",
                 ', '.join([os.path.join(module_path, 'overlays', i,
                                         'kustomization.yaml')

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -201,13 +201,13 @@ class Serverless(RunwayModuleNpm):
             if self.parameters or self.environments or self.env_file:
                 return False
             self.logger.info(
-                'skipping; config file for this stage/region not found'
+                'skipped; config file for this stage/region not found'
                 ' -- looking for one of: %s',
                 ', '.join(gen_sls_config_files(self.stage, self.region))
             )
         else:
             self.logger.info(
-                'skipping; package.json with "serverless" as a devDependencies'
+                'skipped; package.json with "serverless" in devDependencies'
                 ' is required for this module type'
             )
         return True
@@ -233,7 +233,7 @@ class Serverless(RunwayModuleNpm):
             else:  # TODO remove handling when dropping python 2 support
                 tmp_file.write_text(yaml.safe_dump(final_yml).decode('UTF-8'))
             self.logger.debug('created temporary Serverless config: %s',
-                              tmp_file.path)
+                              tmp_file)
             self.options.update_args('config', str(tmp_file.name))
             self.logger.debug(
                 'updated options.args with temporary Serverless config: %s',

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -100,7 +100,7 @@ def deploy_package(sls_opts, bucketname, context, path, logger=LOGGER):
                                             command_opts=sls_opts,
                                             path=path)
 
-    logger.info('package %s (in-progress)', os.path.basename(path))
+    logger.info('package %s (in progress)', os.path.basename(path))
     run_module_command(cmd_list=sls_package_cmd,
                        env_vars=context.env.vars,
                        logger=logger)
@@ -126,7 +126,7 @@ def deploy_package(sls_opts, bucketname, context, path, logger=LOGGER):
                                            command_opts=sls_opts,
                                            path=path)
 
-    logger.info('deploy (in-progress)')
+    logger.info('deploy (in progress)')
     run_module_command(cmd_list=sls_deploy_cmd,
                        env_vars=context.env.vars,
                        logger=logger)
@@ -301,7 +301,7 @@ class Serverless(RunwayModuleNpm):
                            str(self.path),
                            self.logger)
             return
-        self.logger.info('deploy (in-progress)')
+        self.logger.info('deploy (in progress)')
         run_module_command(cmd_list=self.gen_cmd('deploy'),
                            env_vars=self.context.env.vars,
                            logger=self.logger)
@@ -352,7 +352,7 @@ class Serverless(RunwayModuleNpm):
         if not skip_install:
             self.npm_install()
         stack_missing = False  # track output for acceptable error
-        self.logger.info('destroy (in-progress)')
+        self.logger.info('destroy (in progress)')
         proc = subprocess.Popen(self.gen_cmd('remove'),
                                 bufsize=1,
                                 env=self.context.env.vars,

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -104,7 +104,7 @@ class StaticSite(RunwayModule):
             module_dir,
             {i: self.options[i] for i in self.options if i != 'class_path'}
         )
-        self.logger.info('%s (in-progress)', command)
+        self.logger.info('%s (in progress)', command)
         getattr(cfn, command)()
         self.logger.info('%s (complete)', command)
 

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -47,7 +47,7 @@ class StaticSite(RunwayModule):
         if self.parameters:
             self._setup_website_module(command='plan')
         else:
-            self.logger.info('skipping; environment required but not defined')
+            self.logger.info('skipped; environment required but not defined')
 
     def deploy(self):
         """Create website CFN module and run stacker build."""
@@ -75,14 +75,14 @@ class StaticSite(RunwayModule):
                     )
             self._setup_website_module(command='deploy')
         else:
-            self.logger.info('skipping; environment required but not defined')
+            self.logger.info('skipped; environment required but not defined')
 
     def destroy(self):
         """Create website CFN module and run stacker destroy."""
         if self.parameters:
             self._setup_website_module(command='destroy')
         else:
-            self.logger.info('skipping; environment required but not defined')
+            self.logger.info('skipped; environment required but not defined')
 
     def _setup_website_module(self,  # type: StaticSite
                               command  # type: str

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -1,19 +1,18 @@
 """Static website module."""
-
 import logging
 import os
 import sys
 import tempfile
-import warnings
-
 from typing import Any, Dict, List, Union  # pylint: disable=unused-import
 
 import yaml
 
+from .._logging import PrefixAdaptor
+from ..util import YamlDumper
 from . import RunwayModule
 from .cloudformation import CloudFormation
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 def add_url_scheme(url):
@@ -34,10 +33,11 @@ class StaticSite(RunwayModule):
     def __init__(self, context, path, options=None):
         """Initialize."""
         super(StaticSite, self).__init__(context, path, options)
-        self.name = self.options.get('name', self.options.get('path'))
         self.user_options = self.options.get('options', {})
         self.parameters = self.options.get('parameters')  # type: Dict[str, Any]
-        self.region = self.context.env_region
+        self.region = self.context.env.aws_region
+        # logger needs to be created here to use the correct logger
+        self.logger = PrefixAdaptor(self.name, LOGGER)
         self._ensure_valid_environment_config()
         self._ensure_cloudfront_with_auth_at_edge()
         self._ensure_correct_region_with_auth_at_edge()
@@ -47,52 +47,49 @@ class StaticSite(RunwayModule):
         if self.parameters:
             self._setup_website_module(command='plan')
         else:
-            LOGGER.info("Skipping staticsite plan of %s; no environment "
-                        "config found for this environment/region",
-                        self.options['path'])
+            self.logger.info('skipping; environment required but not defined')
 
     def deploy(self):
         """Create website CFN module and run stacker build."""
         if self.parameters:
             if self.parameters.get('staticsite_cf_disable', False) is False:
-                msg = ("Please Note: Initial creation or updates to distribution settings "
-                       "(e.g. url rewrites) will take quite a while (up to an hour). "
-                       "Unless you receive an error your deployment is still running.")
-                LOGGER.info(msg.upper())
+                self.logger.warning(
+                    'initial creation of & updates to distributions can take '
+                    'up to an hour to complete'
+                )
 
                 # Auth@Edge warning about subsequent deploys
-                if self.parameters.get('staticsite_auth_at_edge', False) is True:
-                    msg = ("PLEASE NOTE: A hook that is part of the dependencies stack of "
-                           "the Auth@Edge static site deployment is designed to verify that "
-                           "the correct Callback URLs are being used when a User Pool Client "
-                           "already exists for the application. This ensures that there is no "
-                           "interruption of service while the deployment reaches the stage "
-                           "where the Callback URLs are updated to that of the Distribution. "
-                           "Because of this you will receive a change set request on your first "
-                           "subsequent deploy from the first, or any subsequent ones where the "
-                           "alias domains have changed.")
-                    LOGGER.info(msg)
-
+                if self.parameters.get('staticsite_auth_at_edge', False) and \
+                        self.context.is_interactive:
+                    self.logger.warning(
+                        "A hook that is part of the dependencies stack of "
+                        "the Auth@Edge static site deployment is designed "
+                        "to verify that the correct Callback URLs are "
+                        "being used when a User Pool Client already "
+                        "exists for the application. This ensures that "
+                        "there is no interruption of service while the "
+                        "deployment reaches the stage where the Callback "
+                        "URLs are updated to that of the Distribution. "
+                        "Because of this you may receive a change set "
+                        "prompt on subsequent deploys."
+                    )
             self._setup_website_module(command='deploy')
         else:
-            LOGGER.info("Skipping staticsite deploy of %s; no environment "
-                        "config found for this environment/region",
-                        self.options['path'])
+            self.logger.info('skipping; environment required but not defined')
 
     def destroy(self):
         """Create website CFN module and run stacker destroy."""
         if self.parameters:
             self._setup_website_module(command='destroy')
         else:
-            LOGGER.info("Skipping staticsite destroy of %s; no environment "
-                        "config found for this environment/region",
-                        self.options['path'])
+            self.logger.info('skipping; environment required but not defined')
 
     def _setup_website_module(self,  # type: StaticSite
                               command  # type: str
                              ):  # noqa: E124
         # type(...) -> return None
-        """Create stacker configuration for website module."""
+        """Create CFNgin configuration for website module."""
+        self.logger.info('generating CFNgin config...')
         module_dir = self._create_module_directory()
         self._create_dependencies_yaml(module_dir)
         self._create_staticsite_yaml(module_dir)
@@ -107,14 +104,13 @@ class StaticSite(RunwayModule):
             module_dir,
             {i: self.options[i] for i in self.options if i != 'class_path'}
         )
+        self.logger.info('%s (in-progress)', command)
         getattr(cfn, command)()
+        self.logger.info('%s (complete)', command)
 
     def _create_module_directory(self):
         module_dir = tempfile.mkdtemp()
-        LOGGER.info("staticsite: Generating CloudFormation configuration for "
-                    "module %s in %s",
-                    self.name,
-                    module_dir)
+        self.logger.debug('using temporary directory: %s', module_dir)
         return module_dir
 
     def _create_dependencies_yaml(self, module_dir):
@@ -166,19 +162,25 @@ class StaticSite(RunwayModule):
                     'args': self._get_user_pool_id_retriever_variables(),
                 })
 
+        content = {
+            'namespace': '${namespace}',
+            'cfngin_bucket': '',
+            'stacks': {
+                "%s-dependencies" % self.name: {
+                    'class_path': 'runway.blueprints.staticsite.dependencies.Dependencies',
+                    'variables': self._get_dependencies_variables()
+                }
+            },
+            'pre_build': pre_build,
+            'pre_destroy': pre_destroy
+        }
+
         with open(os.path.join(module_dir, '01-dependencies.yaml'), 'w') as output_stream:  # noqa
-            yaml.dump(
-                {'namespace': '${namespace}',
-                 'cfngin_bucket': '',
-                 'stacks': {
-                     "%s-dependencies" % self.name: {
-                         'class_path': 'runway.blueprints.staticsite.dependencies.Dependencies',
-                         'variables': self._get_dependencies_variables()}},
-                 'pre_build': pre_build,
-                 'pre_destroy': pre_destroy},
-                output_stream,
-                default_flow_style=False
-            )
+            yaml.dump(content, output_stream, default_flow_style=False)
+        self.logger.debug(
+            'created 01-dependencies.yaml:\n%s',
+            yaml.dump(content, Dumper=YamlDumper)
+        )
 
     def _create_staticsite_yaml(self, module_dir):
         # Default parameter name matches build_staticsite hook
@@ -281,21 +283,27 @@ class StaticSite(RunwayModule):
             if self.parameters.get("staticsite_%s" % i):
                 site_stack_variables[i] = self.parameters.pop("staticsite_%s" % i)
 
+        content = {
+            'namespace': '${namespace}',
+            'cfngin_bucket': '',
+            'pre_build': pre_build,
+            'stacks': {
+                self.name: {
+                    'class_path': 'runway.blueprints.staticsite.%s' % class_path,
+                    'variables': site_stack_variables
+                }
+            },
+            'post_build': post_build,
+            'pre_destroy': pre_destroy,
+            'post_destroy': post_destroy
+        }
+
         with open(os.path.join(module_dir, '02-staticsite.yaml'), 'w') as output_stream:  # noqa
-            yaml.dump(
-                {'namespace': '${namespace}',
-                 'cfngin_bucket': '',
-                 'pre_build': pre_build,
-                 'stacks': {
-                     self.name: {
-                         'class_path': 'runway.blueprints.staticsite.%s' % class_path,  # noqa
-                         'variables': site_stack_variables}},
-                 'post_build': post_build,
-                 'pre_destroy': pre_destroy,
-                 'post_destroy': post_destroy},
-                output_stream,
-                default_flow_style=False
-            )
+            yaml.dump(content, output_stream, default_flow_style=False)
+        self.logger.debug(
+            'created 02-staticsite.yaml:\n%s',
+            yaml.dump(content, Dumper=YamlDumper)
+        )
 
     def _create_cleanup_yaml(self, module_dir):
         replicated_function_vars = self._get_replicated_function_variables()
@@ -303,19 +311,23 @@ class StaticSite(RunwayModule):
             replicated_function_vars['RoleBoundaryArn'] = \
                 self.parameters.pop('staticsite_role_boundary_arn')
 
+        content = {
+            'namespace': '${namespace}',
+            'cfngin_bucket': '',
+            'stacks': {
+                '%s-cleanup' % self.name: {
+                    'class_path': 'runway.blueprints.staticsite.cleanup.Cleanup',
+                    'variables': replicated_function_vars
+                }
+            }
+        }
+
         with open(os.path.join(module_dir, '03-cleanup.yaml'), 'w') as output_stream:  # noqa
-            yaml.dump(
-                {'namespace': '${namespace}',
-                 'cfngin_bucket': '',
-                 'stacks': {
-                     '%s-cleanup' % self.name: {
-                         'class_path': 'runway.blueprints.staticsite.cleanup.Cleanup',
-                         'variables': replicated_function_vars
-                     }
-                 }},
-                output_stream,
-                default_flow_style=False
-            )
+            yaml.dump(content, output_stream, default_flow_style=False)
+        self.logger.debug(
+            'created 03-cleanup.yaml:\n%s',
+            yaml.dump(content, Dumper=YamlDumper)
+        )
 
     def _get_replicated_function_variables(self):
         replicated_function_vars = {
@@ -365,15 +377,16 @@ class StaticSite(RunwayModule):
                 self.parameters['staticsite_acmcert_arn']
 
         if self.parameters.get('staticsite_acmcert_ssm_param'):
-            dep_msg = ('Use of the "staticsite_acmcert_ssm_param" option has '
-                       'been deprecated. The "staticsite_acmcert_arn" option '
-                       'with an "ssm" lookup should be used instead.')
-            warnings.warn(dep_msg, DeprecationWarning)
-            LOGGER.warning(dep_msg)
-            site_stack_variables['AcmCertificateArn'] = '${ssmstore ${staticsite_acmcert_ssm_param}}'  # noqa pylint: disable=line-too-long
+            self.logger.warning(
+                'staticsite_acmcert_ssm_param option has been deprecated; '
+                'use staticsite_acmcert_arn with an ssm lookup'
+            )
+            site_stack_variables['AcmCertificateArn'] = \
+                '${ssmstore ${staticsite_acmcert_ssm_param}}'
 
         if self.parameters.get('staticsite_enable_cf_logging', True):
-            site_stack_variables['LogBucketName'] = "${rxref %s-dependencies::AWSLogBucketName}" % self.name  # noqa pylint: disable=line-too-long
+            site_stack_variables['LogBucketName'] = \
+                "${rxref %s-dependencies::AWSLogBucketName}" % self.name
 
         if self.parameters.get('staticsite_auth_at_edge', False):
             self._ensure_auth_at_edge_requirements()
@@ -388,7 +401,8 @@ class StaticSite(RunwayModule):
             site_stack_variables['CookieSettings'] = self._get_cookie_settings()
             site_stack_variables['OAuthScopes'] = self._get_oauth_scopes()
             # pylint: disable=line-too-long
-            site_stack_variables['SupportedIdentityProviders'] = self._get_supported_identity_providers()  # noqa
+            site_stack_variables['SupportedIdentityProviders'] = \
+                self._get_supported_identity_providers()
         else:
             # If lambda_function_associations or custom_error_responses defined,
             # add to stack config. Only if not using Auth@Edge
@@ -509,10 +523,14 @@ class StaticSite(RunwayModule):
         }
 
     def _ensure_auth_at_edge_requirements(self):
-        if not self.parameters.get('staticsite_user_pool_arn') and \
-           not self.parameters.get('staticsite_create_user_pool'):
-            LOGGER.fatal("A Cognito UserPool ARN is required with Auth@Edge. "
-                         "You can supply your own or have one created.")
+        if not (
+                self.parameters.get('staticsite_user_pool_arn') or
+                self.parameters.get('staticsite_create_user_pool')
+        ):
+            self.logger.error(
+                "staticsite_user_pool_arn or staticsite_create_user_pool "
+                "is required for Auth@Edge; "
+            )
             sys.exit(1)
 
     def _ensure_correct_region_with_auth_at_edge(self):
@@ -521,20 +539,21 @@ class StaticSite(RunwayModule):
         Lambda@Edge is only available within the us-east-1 region.
         """
         if self.parameters.get('staticsite_auth_at_edge', False) and self.region != 'us-east-1':
-            LOGGER.fatal("Auth@Edge must be deployed in us-east-1.")
+            self.logger.error("Auth@Edge must be deployed in us-east-1.")
             sys.exit(1)
 
     def _ensure_cloudfront_with_auth_at_edge(self):
         """Exit if both the Auth@Edge and CloudFront disablement are true."""
         if self.parameters.get('staticsite_cf_disable', False) and \
            self.parameters.get('staticsite_auth_at_edge', False):
-            LOGGER.fatal("CloudFront cannot be disabled when using Auth@Edge")
+            self.logger.error(
+                'staticsite_cf_disable must be "false" if '
+                'staticsite_auth_at_edge is "true"'
+            )
             sys.exit(1)
 
     def _ensure_valid_environment_config(self):
         """Exit if config is invalid."""
         if not self.parameters.get('namespace'):
-            LOGGER.fatal("staticsite: module %s's environment configuration is "
-                         "missing a namespace definition!",
-                         self.name)
+            self.logger.error('namespace parameter is required but not defined')
             sys.exit(1)

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -185,7 +185,7 @@ class Terraform(RunwayModule):
                     send2trash(os.path.join(self.path, '.terraform'))
                     self.logger.verbose('.terraform directory deleted')
 
-                self.logger.info('init (in-progress)')
+                self.logger.info('init (in progress)')
                 run_terraform_init(
                     tf_bin=tf_bin,
                     module_path=self.path,
@@ -258,7 +258,7 @@ class Terraform(RunwayModule):
                     env_vars=env_vars,
                     logger=self.logger
                 )
-                self.logger.info('%s (in-progress)', command)
+                self.logger.info('%s (in progress)', command)
                 if any(key.startswith('TF_VAR_') for key, _val in env_vars.items()):
                     self.logger.debug(
                         "Terraform variable environment variables: %s",

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -275,7 +275,7 @@ class Terraform(RunwayModule):
         else:
             response['skipped_configs'] = True
             self.logger.info(
-                'skipping; tfvars for this environmet/region not found '
+                'skipped; tfvars for this environmet/region not found '
                 '-- looking for one of: %s',
                 ', '.join(gen_workspace_tfvars_files(
                     self.context.env.name,

--- a/runway/path.py
+++ b/runway/path.py
@@ -8,7 +8,7 @@ import six
 
 from .sources.git import Git
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class Path(object):  # pylint: disable=too-many-instance-attributes

--- a/runway/runway_module_type.py
+++ b/runway/runway_module_type.py
@@ -23,7 +23,7 @@ class RunwayModuleType(object):
     Runway determines the type of module you are trying to
     deploy in 3 different ways. First, it will check for the
     ``type`` property as described here, next it will look
-    for a suffix as described in :ref:`Module Definition<mod-definition>`,
+    for a suffix as described in :ref:`Module Definition<runway-module>`,
     and finally it will attempt to autodetect your module
     type by scanning the files of the project. If none of
     those settings produces a valid result an error will

--- a/runway/s3_util.py
+++ b/runway/s3_util.py
@@ -71,7 +71,7 @@ def does_bucket_exist(bucket_name, region='us-east-1', session=None):
 def ensure_bucket_exists(bucket_name, region='us-east-1', session=None):
     """Ensure S3 bucket exists."""
     if not does_bucket_exist(bucket_name, region, session):
-        LOGGER.info('creating bucket "%s" (in-progress)', bucket_name)
+        LOGGER.info('creating bucket "%s" (in progress)', bucket_name)
         s3_client = _get_client(session, region)
         if region == 'us-east-1':
             create_bucket_opts = {}

--- a/runway/sources/git.py
+++ b/runway/sources/git.py
@@ -1,19 +1,17 @@
 """'Git' type Path Source."""
 from __future__ import absolute_import
-# pylint: disable=unused-import
-from typing import List, Dict, Optional, Union  # noqa: F401
 
-import tempfile
+import logging
+import os
 import shutil
 import subprocess
-
-import os
 import sys
-import logging
+import tempfile
+from typing import Dict, List, Optional, Union  # noqa pylint: disable=W
 
 from .source import Source
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class Git(Source):
@@ -84,12 +82,13 @@ class Git(Source):
             ref (str): The git reference value
 
         """
-        LOGGER.debug("Invoking git to retrieve commit id for repo %s...", self.uri)
-        lsremote_output = subprocess.check_output(['git', 'ls-remote', self.uri, ref])
+        cmd = ['git', 'ls-remote', self.uri, ref]
+        LOGGER.debug('getting commit ID from repo: %s', ' '.join(cmd))
+        lsremote_output = subprocess.check_output(cmd)
         # pylint: disable=unsupported-membership-test
         if b"\t" in lsremote_output:
             commit_id = lsremote_output.split(b"\t")[0]  # type List[str]
-            LOGGER.debug("Matching commit id found: %s", commit_id)
+            LOGGER.debug("matching commit id found: %s", commit_id)
             return commit_id
         raise ValueError("Ref \"%s\" not found for repo %s." % (ref, self.uri))
 

--- a/runway/sources/source.py
+++ b/runway/sources/source.py
@@ -4,13 +4,11 @@ Abstract parent class for a 'Source' type object.
 Allows us to specify specific remote sourced resources for out application
 (Git, S3, ect.)
 """
-# pylint: disable=unused-import
-from typing import Dict, Optional, Union  # noqa: F401
-
-import os
 import logging
+import os
+from typing import Dict, Optional, Union  # noqa pylint: disable=W
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class Source(object):

--- a/runway/tests/handlers/base.py
+++ b/runway/tests/handlers/base.py
@@ -1,6 +1,6 @@
 """Base module for test handlers."""
 import os
-from typing import Dict, Any, List  # pylint: disable=unused-import
+from typing import Any, Dict, List  # noqa pylint: disable=W
 
 
 class TestHandler(object):

--- a/runway/tests/handlers/cfn_lint.py
+++ b/runway/tests/handlers/cfn_lint.py
@@ -2,10 +2,11 @@
 import logging
 import runpy
 import sys
-from typing import Any, Dict  # pylint: disable=unused-import
+from typing import Any, Dict  # noqa pylint: disable=W
 
 import yaml
 
+from ..._logging import PrefixAdaptor
 from ...util import argv
 from .base import TestHandler
 
@@ -15,7 +16,7 @@ else:
     from pathlib import Path  # pylint: disable=E
 
 TYPE_NAME = 'cfn-lint'
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class CfnLintHandler(TestHandler):
@@ -29,10 +30,11 @@ class CfnLintHandler(TestHandler):
         Relies on .cfnlintrc file to be located beside the Runway config file.
 
         """
+        logger = PrefixAdaptor(name, LOGGER)
         cfnlintrc = Path('./.cfnlintrc')
 
         if not cfnlintrc.is_file():
-            LOGGER.error('File must exist to use this test: %s', cfnlintrc)
+            logger.error('file must exist to use this test: %s', cfnlintrc)
             sys.exit(1)
 
         # prevent duplicate log messages by not passing to the root logger
@@ -44,6 +46,6 @@ class CfnLintHandler(TestHandler):
             if err.code != 0:  # ignore zero exit codes but re-raise for non-zero
                 if not (yaml.safe_load(cfnlintrc.read_text()) or
                         {}).get('templates'):
-                    LOGGER.warning('cfnlintrc is missing a "templates" '
+                    logger.warning('cfnlintrc is missing a "templates" '
                                    'section which is required by cfn-lint')
                 raise

--- a/runway/tests/handlers/script.py
+++ b/runway/tests/handlers/script.py
@@ -1,14 +1,15 @@
 """Script test runner."""
 import logging
-import sys
 import subprocess
+import sys
 from subprocess import CalledProcessError
-from typing import Dict, Any  # pylint: disable=unused-import
+from typing import Any, Dict  # noqa pylint: disable=W
 
-from runway.tests.handlers.base import TestHandler
+from ..._logging import PrefixAdaptor
+from ...tests.handlers.base import TestHandler
 
 TYPE_NAME = 'script'
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class ScriptHandler(TestHandler):
@@ -34,15 +35,15 @@ class ScriptHandler(TestHandler):
     def handle(cls, name, args):
         # type: (str, Dict[str, Any]) -> None
         """Perform the actual test."""
+        logger = PrefixAdaptor(name, LOGGER)
         for cmd in args['commands']:
             try:
                 exit_code = subprocess.call(cmd, shell=True)
                 if exit_code != 0:
                     raise ValueError(exit_code)
             except CalledProcessError as err:
-                LOGGER.error('%s: failed to execute command: %s',
-                             name, cmd)
+                logger.error('failed to execute command: %s', cmd)
                 raise err
             except ValueError:
-                LOGGER.error('%s: failed command: %s', name, cmd)
+                logger.error('failed command: %s', cmd)
                 sys.exit(1)

--- a/runway/tests/handlers/yaml_lint.py
+++ b/runway/tests/handlers/yaml_lint.py
@@ -6,11 +6,11 @@ import os
 import runpy
 from typing import Any, Dict, List  # pylint: disable=unused-import
 
-from runway.tests.handlers.base import TestHandler
-from runway.util import argv
+from ...tests.handlers.base import TestHandler
+from ...util import argv
 
 TYPE_NAME = 'yamllint'
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 class YamllintHandler(TestHandler):

--- a/runway/tests/registry.py
+++ b/runway/tests/registry.py
@@ -3,11 +3,8 @@
 from past.builtins import basestring
 
 from ..util import load_object_from_string
-
-from .handlers import script
-from .handlers import cfn_lint
+from .handlers import cfn_lint, script
 from .handlers import yaml_lint as yamllint
-
 
 TEST_HANDLERS = {}
 

--- a/runway/util.py
+++ b/runway/util.py
@@ -319,7 +319,7 @@ class SafeHaven(AbstractContextManager):
         self.__sys_modules = {k: v for k, v in sys.modules.items()}
         self.__sys_path = list(sys.path)
         # more informative origin for log statements
-        self.log = logging.getLogger('runway.' + self.__class__.__name__)
+        self.logger = logging.getLogger('runway.' + self.__class__.__name__)
         self.sys_modules_exclude = sys_modules_exclude or []
 
         if isinstance(argv, list):
@@ -331,7 +331,7 @@ class SafeHaven(AbstractContextManager):
 
     def reset_all(self):
         """Reset all values cached by this context manager."""
-        self.log.debug('resetting all managed values...')
+        self.logger.debug('resetting all managed values...')
         self.reset_os_environ()
         self.reset_sys_argv()
         self.reset_sys_modules()
@@ -339,18 +339,18 @@ class SafeHaven(AbstractContextManager):
 
     def reset_os_environ(self):
         """Reset the value of os.environ."""
-        self.log.debug('resetting os.environ: %s', self.__os_environ)
+        self.logger.debug('resetting os.environ: %s', self.__os_environ)
         os.environ.clear()
         os.environ.update(self.__os_environ)
 
     def reset_sys_argv(self):
         """Reset the value of sys.argv."""
-        self.log.debug('resetting sys.argv: %s', self.__sys_argv)
+        self.logger.debug('resetting sys.argv: %s', self.__sys_argv)
         sys.argv = self.__sys_argv
 
     def reset_sys_modules(self):
         """Reset the value of sys.modules."""
-        self.log.debug('resetting sys.modules...')
+        self.logger.debug('resetting sys.modules...')
         # sys.modules can be manipulated to force reloading modules but,
         # replacing it outright does not work as expected
         for module in list(sys.modules.keys()):
@@ -362,7 +362,7 @@ class SafeHaven(AbstractContextManager):
 
     def reset_sys_path(self):
         """Reset the value of sys.path."""
-        self.log.debug('resetting sys.path: %s', self.__sys_path)
+        self.logger.debug('resetting sys.path: %s', self.__sys_path)
         sys.path = self.__sys_path
 
     def __enter__(self):
@@ -372,12 +372,12 @@ class SafeHaven(AbstractContextManager):
             SafeHaven: Instance of the context manager.
 
         """
-        self.log.debug('entering a safe haven...')
+        self.logger.debug('entering a safe haven...')
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit the context manager."""
-        self.log.debug('leaving the safe haven...')
+        self.logger.debug('leaving the safe haven...')
         self.reset_all()
 
 

--- a/runway/util.py
+++ b/runway/util.py
@@ -339,13 +339,15 @@ class SafeHaven(AbstractContextManager):
 
     def reset_os_environ(self):
         """Reset the value of os.environ."""
-        self.logger.debug('resetting os.environ: %s', self.__os_environ)
+        self.logger.debug('resetting os.environ: %s',
+                          json.dumps(self.__os_environ))
         os.environ.clear()
         os.environ.update(self.__os_environ)
 
     def reset_sys_argv(self):
         """Reset the value of sys.argv."""
-        self.logger.debug('resetting sys.argv: %s', self.__sys_argv)
+        self.logger.debug('resetting sys.argv: %s',
+                          json.dumps(self.__sys_argv))
         sys.argv = self.__sys_argv
 
     def reset_sys_modules(self):
@@ -362,7 +364,7 @@ class SafeHaven(AbstractContextManager):
 
     def reset_sys_path(self):
         """Reset the value of sys.path."""
-        self.logger.debug('resetting sys.path: %s', self.__sys_path)
+        self.logger.debug('resetting sys.path: %s', json.dumps(self.__sys_path))
         sys.path = self.__sys_path
 
     def __enter__(self):

--- a/runway/util.py
+++ b/runway/util.py
@@ -357,8 +357,8 @@ class SafeHaven(AbstractContextManager):
             if module not in self.__sys_modules and \
                     not any(module.startswith(n)
                             for n in self.sys_modules_exclude):
-                self.log.debug('removed sys.module: {"%s": "%s"}', module,
-                               sys.modules.pop(module))
+                self.logger.debug('removed sys.module: {"%s": "%s"}', module,
+                                  sys.modules.pop(module))
 
     def reset_sys_path(self):
         """Reset the value of sys.path."""

--- a/runway/util.py
+++ b/runway/util.py
@@ -16,6 +16,7 @@ from typing import (Any, Dict, Iterator,  # noqa pylint: disable=unused-import
                     List, Optional, Union)
 
 import six
+import yaml
 
 if sys.version_info >= (3, 6):
     from contextlib import AbstractContextManager  # pylint: disable=E
@@ -24,6 +25,7 @@ else:
 
 AWS_ENV_VARS = ('AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY',
                 'AWS_SESSION_TOKEN')
+DOC_SITE = 'https://docs.onica.com/projects/runway'
 EMBEDDED_LIB_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     'embedded'
@@ -377,6 +379,28 @@ class SafeHaven(AbstractContextManager):
         """Exit the context manager."""
         self.log.debug('leaving the safe haven...')
         self.reset_all()
+
+
+# TODO remove after https://github.com/yaml/pyyaml/issues/234 is resolved
+class YamlDumper(yaml.Dumper):
+    """Custom YAML Dumper.
+
+    This Dumper allows for YAML to be output to follow YAML spec 1.2,
+    example 2.3 of collections (2.1). This provides an output that is more
+    humanreadable and complies with yamllint.
+
+    Example:
+        >>> print(yaml.dump({'key': ['val1', 'val2']}, Dumper=YamlDumper))
+
+    Note:
+        YAML 1.2 Specification: https://yaml.org/spec/1.2/spec.html
+        used for reference.
+
+    """
+
+    def increase_indent(self, flow=False, indentless=False):
+        """Override parent method."""
+        return super(YamlDumper, self).increase_indent(flow, False)
 
 
 @contextmanager

--- a/runway/variables.py
+++ b/runway/variables.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from .config import VariablesDefinition  # noqa: F401 pylint: disable=unused-import
 
 
-LOGGER = logging.getLogger('runway')
+LOGGER = logging.getLogger(__name__)
 
 
 def resolve_variables(variables, context, provider):
@@ -51,10 +51,10 @@ class Variable(object):
             value: The variable itself.
 
         """
-        LOGGER.debug('Initalized variable "%s".', name)
         self.name = name
         self._raw_value = value
         self._value = VariableValue.parse(value, variable_type)
+        LOGGER.debug('initalized variable: %s', name)
 
     @property
     def dependencies(self):
@@ -668,7 +668,7 @@ class VariableValueLookup(VariableValue):
             if isinstance(err, TypeError):
                 # handle lookups that don't accept all the args we want
                 # to pass to it
-                LOGGER.debug('Encountered %s: %s - trying legacy resolver',
+                LOGGER.debug('encountered %s: %s - trying legacy resolver',
                              type(err), err)
                 try:
                     return self._resolve(self._resolve_legacy(context=context,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ INSTALL_REQUIRES = [
     'cfn_flip>=1.2.1',  # 1.2.1+ require PyYAML 4.1+
     'cfn-lint',
     'click>=7.1',
+    'coloredlogs',
     'docker',
     'requests',
     'future',

--- a/tests/integration/cli/commands/test_dismantle.py
+++ b/tests/integration/cli/commands/test_dismantle.py
@@ -25,4 +25,4 @@ def test_dismantle(caplog, cd_tmp_path, cp_config, monkeypatch):
     assert 'forwarding to destroy...' in caplog.messages
     mock_forward.assert_called_once_with(destroy, ci=True, debug=0,
                                          deploy_environment='test',
-                                         tags=('tag1', 'tag2'))
+                                         tags=('tag1', 'tag2'), verbose=False)

--- a/tests/integration/cli/commands/test_dismantle.py
+++ b/tests/integration/cli/commands/test_dismantle.py
@@ -19,10 +19,12 @@ def test_dismantle(caplog, cd_tmp_path, cp_config, monkeypatch):
     result = runner.invoke(cli, ['dismantle',
                                  '--ci',
                                  '--deploy-environment', 'test',
+                                 '--no-color',
                                  '--tag', 'tag1',
                                  '--tag', 'tag2'])
     assert result.exit_code == 0
     assert 'forwarding to destroy...' in caplog.messages
     mock_forward.assert_called_once_with(destroy, ci=True, debug=0,
                                          deploy_environment='test',
+                                         no_color=True,
                                          tags=('tag1', 'tag2'), verbose=False)

--- a/tests/integration/cli/commands/test_gen_sample.py
+++ b/tests/integration/cli/commands/test_gen_sample.py
@@ -201,7 +201,7 @@ def test_k8s_cfn_repo(cd_tmp_path, caplog):
 
     assert caplog.messages == [
         'Sample k8s infrastructure repo created at {}'.format(str(repo)),
-        '(see its README for setup and deployment instructions)'
+        'See the README for setup and deployment instructions.'
     ]
 
 
@@ -248,7 +248,7 @@ def test_k8s_tf_repo(cd_tmp_path, caplog):
 
     assert caplog.messages == [
         'Sample k8s infrastructure repo created at {}'.format(str(repo)),
-        '(see its README for setup and deployment instructions)'
+        'See the README for setup and deployment instructions.'
     ]
 
 
@@ -322,8 +322,8 @@ def test_stacker(cd_tmp_path, caplog):
     runner = CliRunner()
     result = runner.invoke(cli, ['gen-sample', 'stacker'])
     assert result.exit_code == 0
-    assert caplog.messages == ['This command has been deprecated and will be '
-                               'removed in the next major release.']
+    assert caplog.messages[0] == ('This command has been deprecated and will be '
+                                  'removed in the next major release.')
 
 
 def test_static_angular(cd_tmp_path, caplog):
@@ -376,7 +376,7 @@ def test_static_angular(cd_tmp_path, caplog):
 
     assert caplog.messages == [
         'Sample static Angular site repo created at {}'.format(str(repo)),
-        '(see its README for setup and deployment instructions)'
+        'See the README for setup and deployment instructions.'
     ]
 
 
@@ -416,7 +416,7 @@ def test_static_react(cd_tmp_path, caplog):
 
     assert caplog.messages == [
         'Sample static React site repo created at {}'.format(str(repo)),
-        '(see its README for setup and deployment instructions)'
+        'See the README for setup and deployment instructions.'
     ]
 
 

--- a/tests/integration/cli/commands/test_preflight.py
+++ b/tests/integration/cli/commands/test_preflight.py
@@ -20,4 +20,9 @@ def test_preflight(caplog, cd_tmp_path, cp_config, monkeypatch):
                                  '--deploy-environment', 'test'])
     assert result.exit_code == 0
     assert 'forwarding to test...' in caplog.messages
-    mock_forward.assert_called_once_with(test, debug=0, deploy_environment='test')
+    mock_forward.assert_called_once_with(
+        test,
+        debug=0,
+        deploy_environment='test',
+        verbose=False
+    )

--- a/tests/integration/cli/commands/test_preflight.py
+++ b/tests/integration/cli/commands/test_preflight.py
@@ -24,5 +24,6 @@ def test_preflight(caplog, cd_tmp_path, cp_config, monkeypatch):
         test,
         debug=0,
         deploy_environment='test',
+        no_color=False,
         verbose=False
     )

--- a/tests/integration/cli/commands/test_takeoff.py
+++ b/tests/integration/cli/commands/test_takeoff.py
@@ -25,4 +25,5 @@ def test_takeoff(caplog, cd_tmp_path, cp_config, monkeypatch):
     assert 'forwarding to deploy...' in caplog.messages
     mock_forward.assert_called_once_with(deploy, ci=True, debug=0,
                                          deploy_environment='test',
-                                         tags=('tag1', 'tag2'))
+                                         tags=('tag1', 'tag2'),
+                                         verbose=False)

--- a/tests/integration/cli/commands/test_takeoff.py
+++ b/tests/integration/cli/commands/test_takeoff.py
@@ -25,5 +25,6 @@ def test_takeoff(caplog, cd_tmp_path, cp_config, monkeypatch):
     assert 'forwarding to deploy...' in caplog.messages
     mock_forward.assert_called_once_with(deploy, ci=True, debug=0,
                                          deploy_environment='test',
+                                         no_color=False,
                                          tags=('tag1', 'tag2'),
                                          verbose=False)

--- a/tests/integration/cli/commands/test_taxi.py
+++ b/tests/integration/cli/commands/test_taxi.py
@@ -25,4 +25,5 @@ def test_taxi(caplog, cd_tmp_path, cp_config, monkeypatch):
     assert 'forwarding to plan...' in caplog.messages
     mock_forward.assert_called_once_with(plan, ci=True, debug=0,
                                          deploy_environment='test',
-                                         tags=('tag1', 'tag2'))
+                                         tags=('tag1', 'tag2'),
+                                         verbose=False)

--- a/tests/integration/cli/commands/test_taxi.py
+++ b/tests/integration/cli/commands/test_taxi.py
@@ -25,5 +25,6 @@ def test_taxi(caplog, cd_tmp_path, cp_config, monkeypatch):
     assert 'forwarding to plan...' in caplog.messages
     mock_forward.assert_called_once_with(plan, ci=True, debug=0,
                                          deploy_environment='test',
+                                         no_color=False,
                                          tags=('tag1', 'tag2'),
                                          verbose=False)

--- a/tests/integration/cli/commands/test_test.py
+++ b/tests/integration/cli/commands/test_test.py
@@ -57,9 +57,9 @@ def test_test_invalid_type(cd_tmp_path, capfd, caplog):
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
     assert 'found 2 test(s)' in logs
-    assert 'invalid-type:running test (in-progress)' in logs
+    assert 'invalid-type:running test (in progress)' in logs
     assert 'invalid-type:unable to find handler of type "invalid"' in logs
-    assert "success:running test (in-progress)" in logs
+    assert "success:running test (in progress)" in logs
     assert 'Hello world' in captured.out
     assert "success:running test (pass)" in logs
 
@@ -78,9 +78,9 @@ def test_test_invalid_type_required(cd_tmp_path, caplog):
 
     logs = '\n'.join(caplog.messages)
     assert 'found 2 test(s)' in logs
-    assert 'invalid-type-required:running test (in-progress)' in logs
+    assert 'invalid-type-required:running test (in progress)' in logs
     assert 'invalid-type-required:unable to find handler of type "invalid"' in logs
-    assert "success:running test (in-progress)" not in logs
+    assert "success:running test (in progress)" not in logs
 
 
 def test_test_not_defined(cd_tmp_path, caplog):
@@ -109,7 +109,7 @@ def test_test_single_successful(cd_tmp_path, capfd, caplog):
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
     assert 'found 1 test(s)' in logs
-    assert "success:running test (in-progress)" in logs
+    assert "success:running test (in progress)" in logs
     assert 'Hello world' in captured.out
     assert "success:running test (pass)" in logs
 
@@ -129,9 +129,9 @@ def test_test_two_test(cd_tmp_path, capfd, caplog):
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
     assert 'found 2 test(s)' in logs
-    assert "fail:running test (in-progress)" in logs
+    assert "fail:running test (in progress)" in logs
     assert 'fail:running test (fail)' in logs
-    assert "success:running test (in-progress)" in logs
+    assert "success:running test (in progress)" in logs
     assert 'Hello world' in captured.out
     assert "success:running test (pass)" in logs
     assert 'the following tests failed: fail' in logs
@@ -152,9 +152,9 @@ def test_test_two_test_required(cd_tmp_path, capfd, caplog):
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
     assert 'found 2 test(s)' in logs
-    assert "fail-required:running test (in-progress)" in logs
+    assert "fail-required:running test (in progress)" in logs
     assert "fail-required:running test (fail)" in logs
     assert 'fail-required:test required; the remaining tests have been skipped' \
         in logs
-    assert "success:running test (in-progress)" not in logs
+    assert "success:running test (in progress)" not in logs
     assert 'Hello world' not in captured.out

--- a/tests/integration/cli/commands/test_test.py
+++ b/tests/integration/cli/commands/test_test.py
@@ -56,15 +56,15 @@ def test_test_invalid_type(cd_tmp_path, capfd, caplog):
 
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
-    assert 'Found 2 test(s)' in logs
-    assert "Running test 'invalid-type'" in logs
-    assert 'Unable to find handler for test "invalid-type" of type "invalid"' in logs
-    assert "Running test 'success'" in logs
+    assert 'found 2 test(s)' in logs
+    assert 'invalid-type:running test (in-progress)' in logs
+    assert 'invalid-type:unable to find handler of type "invalid"' in logs
+    assert "success:running test (in-progress)" in logs
     assert 'Hello world' in captured.out
-    assert 'The following tests failed: invalid-type' in logs
+    assert "success:running test (pass)" in logs
 
 
-def test_test_invalid_type_required(cd_tmp_path, capfd, caplog):
+def test_test_invalid_type_required(cd_tmp_path, caplog):
     """Test ``runway test`` with two tests; one invalid required."""
     caplog.set_level(logging.INFO, logger='runway.core')
     runway_yml = cd_tmp_path / 'runway.yml'
@@ -76,25 +76,23 @@ def test_test_invalid_type_required(cd_tmp_path, capfd, caplog):
     result = runner.invoke(cli, ['test'])
     assert result.exit_code == 1
 
-    captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
-    assert 'Found 2 test(s)' in logs
-    assert "Running test 'invalid-type-required'" in logs
-    assert 'Unable to find handler for test "invalid-type-required" of type "invalid"' in logs
-    assert "Running test 'success'" not in logs
-    assert 'Hello world' not in captured.out
+    assert 'found 2 test(s)' in logs
+    assert 'invalid-type-required:running test (in-progress)' in logs
+    assert 'invalid-type-required:unable to find handler of type "invalid"' in logs
+    assert "success:running test (in-progress)" not in logs
 
 
 def test_test_not_defined(cd_tmp_path, caplog):
     """Test ``runway test`` with no tests defined."""
-    caplog.set_level(logging.ERROR, logger='runway')
+    caplog.set_level(logging.ERROR)
     runway_yml = cd_tmp_path / 'runway.yml'
     runway_yml.write_text(six.u(yaml.safe_dump({'deployments': []})))
 
     runner = CliRunner()
     result = runner.invoke(cli, ['test'])
     assert result.exit_code == 1
-    assert 'without defining tests in the runway config' in caplog.messages[0]
+    assert 'no tests defined in runway.yml' in caplog.messages
 
 
 def test_test_single_successful(cd_tmp_path, capfd, caplog):
@@ -110,9 +108,10 @@ def test_test_single_successful(cd_tmp_path, capfd, caplog):
 
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
-    assert 'Found 1 test(s)' in logs
-    assert "Running test 'success'" in logs
+    assert 'found 1 test(s)' in logs
+    assert "success:running test (in-progress)" in logs
     assert 'Hello world' in captured.out
+    assert "success:running test (pass)" in logs
 
 
 def test_test_two_test(cd_tmp_path, capfd, caplog):
@@ -129,17 +128,18 @@ def test_test_two_test(cd_tmp_path, capfd, caplog):
 
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
-    assert 'Found 2 test(s)' in logs
-    assert "Running test 'fail'" in logs
-    assert 'Test failed: fail' in logs
-    assert "Running test 'success'" in logs
+    assert 'found 2 test(s)' in logs
+    assert "fail:running test (in-progress)" in logs
+    assert 'fail:running test (fail)' in logs
+    assert "success:running test (in-progress)" in logs
     assert 'Hello world' in captured.out
-    assert 'The following tests failed: fail' in logs
+    assert "success:running test (pass)" in logs
+    assert 'the following tests failed: fail' in logs
 
 
 def test_test_two_test_required(cd_tmp_path, capfd, caplog):
     """Test ``runway test`` with two tests; one failing required."""
-    caplog.set_level(logging.INFO, logger='runway.core')
+    caplog.set_level(logging.INFO)
     runway_yml = cd_tmp_path / 'runway.yml'
     runway_yml.write_text(six.u(yaml.safe_dump({'deployments': [],
                                                 'tests': [FAIL_REQUIRED.copy(),
@@ -151,9 +151,10 @@ def test_test_two_test_required(cd_tmp_path, capfd, caplog):
 
     captured = capfd.readouterr()
     logs = '\n'.join(caplog.messages)
-    assert 'Found 2 test(s)' in logs
-    assert "Running test 'fail-required'" in logs
-    assert 'Test failed: fail-required' in logs
-    assert 'Failed test was required, the remaining tests have been skipped' in logs
-    assert "Running test 'success'" not in logs
+    assert 'found 2 test(s)' in logs
+    assert "fail-required:running test (in-progress)" in logs
+    assert "fail-required:running test (fail)" in logs
+    assert 'fail-required:test required; the remaining tests have been skipped' \
+        in logs
+    assert "success:running test (in-progress)" not in logs
     assert 'Hello world' not in captured.out

--- a/tests/integration/cli/commands/test_whichenv.py
+++ b/tests/integration/cli/commands/test_whichenv.py
@@ -17,9 +17,6 @@ def test_whichenv(caplog, cd_tmp_path):
     result = runner.invoke(cli, ['whichenv'], env={})
     assert result.exit_code == 0
     assert result.output == cd_tmp_path.name + '\n'
-    assert 'set level of all loggers to INFO' in caplog.messages
-    assert 'set level of botocore logger to ERROR' in caplog.messages
-    assert 'set level of runway logger to DEBUG' not in caplog.messages
 
 
 def test_whichenv_debug(caplog, cd_tmp_path):
@@ -31,9 +28,8 @@ def test_whichenv_debug(caplog, cd_tmp_path):
     runner = CliRunner()
     result = runner.invoke(cli, ['whichenv', '--debug'])
     assert result.exit_code == 0
-    assert 'set level of all loggers to INFO' in caplog.messages
-    assert 'set level of botocore logger to ERROR' in caplog.messages
-    assert 'set level of runway logger to DEBUG' in caplog.messages
+    assert 'runway log level: 10' in caplog.messages
+    assert 'set dependency log level to debug' not in caplog.messages
 
 
 def test_whichenv_debug_debug(caplog, cd_tmp_path):
@@ -45,7 +41,8 @@ def test_whichenv_debug_debug(caplog, cd_tmp_path):
     runner = CliRunner()
     result = runner.invoke(cli, ['whichenv'], env={'DEBUG': '2'})
     assert result.exit_code == 0
-    assert 'set level of all loggers to DEBUG' in caplog.messages
+    assert 'runway log level: 10' in caplog.messages
+    assert 'set dependency log level to debug' in caplog.messages
 
 
 def test_whichenv_invalid_debug_environ(cd_tmp_path):

--- a/tests/unit/cfngin/hooks/test_base.py
+++ b/tests/unit/cfngin/hooks/test_base.py
@@ -64,8 +64,8 @@ class TestHook(object):
         with caplog.at_level(logging.INFO, logger='runway.cfngin.hooks.base'):
             assert hook.deploy_stack(stack=stack, wait=False) == COMPLETE
 
-        assert caplog.records[0].message == '%s: %s' % (stack.name,
-                                                        COMPLETE.name)
+        assert caplog.records[0].message == '%s:%s' % (stack.name,
+                                                       COMPLETE.name)
 
     @patch('runway.cfngin.hooks.base.HookBuildAction.run',
            MagicMock(side_effect=[SUBMITTED, COMPLETE]))
@@ -78,11 +78,11 @@ class TestHook(object):
         with caplog.at_level(logging.DEBUG, logger='runway.cfngin.hooks.base'):
             assert hook.deploy_stack(stack=stack, wait=True) == COMPLETE
 
-        assert caplog.records[0].message == '%s: %s' % (stack.name,
-                                                        SUBMITTED.name)
-        assert caplog.records[1].message == 'Waiting for stack to complete...'
-        assert caplog.records[2].message == '%s: %s' % (stack.name,
-                                                        COMPLETE.name)
+        assert caplog.records[0].message == '%s:%s' % (stack.name,
+                                                       SUBMITTED.name)
+        assert caplog.records[1].message == 'waiting for stack to complete...'
+        assert caplog.records[2].message == '%s:%s' % (stack.name,
+                                                       COMPLETE.name)
 
     @patch('runway.cfngin.hooks.base.HookBuildAction.run',
            MagicMock(side_effect=[SKIPPED]))
@@ -95,8 +95,8 @@ class TestHook(object):
         with caplog.at_level(logging.INFO, logger='runway.cfngin.hooks.base'):
             assert hook.deploy_stack(stack=stack, wait=True) == SKIPPED
 
-        assert caplog.records[0].message == '%s: %s' % (stack.name,
-                                                        SKIPPED.name)
+        assert caplog.records[0].message == '%s:%s' % (stack.name,
+                                                       SKIPPED.name)
 
     @patch('runway.cfngin.hooks.base.HookBuildAction.run',
            MagicMock(side_effect=[FAILED]))
@@ -120,10 +120,10 @@ class TestHook(object):
         with caplog.at_level(logging.DEBUG, logger='runway.cfngin.hooks.base'):
             assert hook.destroy_stack(stack=stack, wait=True) == COMPLETE
 
-        assert caplog.records[0].message == '%s: %s' % (stack.name,
-                                                        SUBMITTED.name)
-        assert caplog.records[1].message == 'Waiting for stack to complete...'
-        assert caplog.records[2].message == '%s: %s (%s)' % (
+        assert caplog.records[0].message == '%s:%s' % (stack.name,
+                                                       SUBMITTED.name)
+        assert caplog.records[1].message == 'waiting for stack to complete...'
+        assert caplog.records[2].message == '%s:%s (%s)' % (
             stack.name, COMPLETE_W_REASON.name, COMPLETE_W_REASON.reason
         )
 

--- a/tests/unit/cfngin/hooks/test_ecs.py
+++ b/tests/unit/cfngin/hooks/test_ecs.py
@@ -42,7 +42,7 @@ class TestECSHooks(unittest.TestCase):
                     (
                         logger,
                         "DEBUG",
-                        "Creating ECS cluster: %s" % cluster
+                        "creating ECS cluster: %s" % cluster
                     )
                 )
 
@@ -72,7 +72,7 @@ class TestECSHooks(unittest.TestCase):
                         (
                             logger,
                             "DEBUG",
-                            "Creating ECS cluster: %s" % cluster
+                            "creating ECS cluster: %s" % cluster
                         )
                     )
 
@@ -97,7 +97,7 @@ class TestECSHooks(unittest.TestCase):
                     (
                         logger,
                         "ERROR",
-                        "setup_clusters hook missing \"clusters\" argument"
+                        "clusters argument required but not provided"
                     )
                 )
 

--- a/tests/unit/cfngin/hooks/test_keypair.py
+++ b/tests/unit/cfngin/hooks/test_keypair.py
@@ -150,17 +150,13 @@ def test_create_in_ssm(provider, context, ssh_key, ssm_key_id):
     assert param_details.get('KeyId') == ssm_key_id
 
 
-def test_interactive_non_terminal_input(capsys, provider, context):
+def test_interactive_non_terminal_input(provider, context):
     """Test interactive non terminal input."""
     with mock_input(isatty=False) as _input:
         result = ensure_keypair_exists(provider, context,
                                        keypair=KEY_PAIR_NAME)
         _input.assert_not_called()
     assert result is False
-
-    output = capsys.readouterr()
-    assert not output.out
-    assert not output.err
 
 
 def test_interactive_retry_cancel(provider, context):

--- a/tests/unit/core/components/test_deploy_environment.py
+++ b/tests/unit/core/components/test_deploy_environment.py
@@ -265,6 +265,20 @@ class TestDeployEnvironment(object):
         assert obj.name == expected
         assert obj.name_derived_from == 'directory'
 
+    def test_verbose(self):
+        """Test verbose."""
+        obj = DeployEnvironment(environ={})
+
+        assert not obj.verbose
+
+        obj.verbose = True
+        assert obj.verbose
+        assert obj.vars['VERBOSE'] == '1'
+
+        obj.verbose = False
+        assert not obj.verbose
+        assert 'VERBOSE' not in obj.vars
+
     def test_copy(self, monkeypatch, tmp_path):
         """Test copy."""
         monkeypatch.setattr(DeployEnvironment, 'name', 'test')

--- a/tests/unit/core/components/test_deploy_environment.py
+++ b/tests/unit/core/components/test_deploy_environment.py
@@ -293,18 +293,21 @@ class TestDeployEnvironment(object):
         assert obj_copy.vars == obj.vars
 
     @pytest.mark.parametrize('derived_from, expected', [
-        ('explicit', ['Environment "test" is explicitly defined in the environment.',
-                      'If this is not correct, update '
-                      'the value or unset it to fall back to the name of '
-                      'the current git branch or parent directory.']),
-        ('branch', ['Environment "test" was determined from the current git branch.',
-                    'If this is not the environment name, update the '
-                    'branch name or set an override via the '
-                    'DEPLOY_ENVIRONMENT environment variable.']),
-        ('directory', ['Environment "test" was determined from the current directory.',
-                       'If this is not the environment name, update the '
-                       'directory name or set an override via the '
-                       'DEPLOY_ENVIRONMENT environment variable.'])
+        ('explicit', ['deploy environment "test" is explicitly defined '
+                      'in the environment',
+                      'if not correct, update the value or unset it to '
+                      'fall back to the name of the current git branch '
+                      'or parent directory']),
+        ('branch', ['deploy environment "test" was determined from the '
+                    'current git branch',
+                    'if not correct, update the branch name or set an '
+                    'override via the DEPLOY_ENVIRONMENT environment '
+                    'variable']),
+        ('directory', ['deploy environment "test" was determined from '
+                       'the current directory',
+                       'if not correct, update the directory name or '
+                       'set an override via the DEPLOY_ENVIRONMENT '
+                       'environment variable'])
     ])
     def test_log_name(self, derived_from, expected, caplog, monkeypatch):
         """Test log_name."""

--- a/tests/unit/core/components/test_deploy_environment.py
+++ b/tests/unit/core/components/test_deploy_environment.py
@@ -294,8 +294,6 @@ class TestDeployEnvironment(object):
     ])
     def test_log_name(self, derived_from, expected, caplog, monkeypatch):
         """Test log_name."""
-        expected.insert(0, '')
-        expected.append('')
         caplog.set_level(logging.INFO, logger='runway')
         monkeypatch.setattr(DeployEnvironment, 'name', 'test')
         obj = DeployEnvironment()

--- a/tests/unit/core/components/test_deployment.py
+++ b/tests/unit/core/components/test_deployment.py
@@ -182,7 +182,7 @@ class TestDeployment(object):
         obj = Deployment(context=runway_context,
                          definition=fx_deployments.load('simple_parallel_regions'))
         assert not obj.deploy()
-        assert 'Processing regions in parallel... (output will be interwoven)' in \
+        assert 'deployment_1:processing regions in parallel... (output will be interwoven)' in \
             caplog.messages
         mock_futures.ProcessPoolExecutor.assert_called_once_with(
             max_workers=runway_context.env.max_concurrent_regions
@@ -205,7 +205,7 @@ class TestDeployment(object):
         obj = Deployment(context=runway_context,
                          definition=fx_deployments.load('simple_parallel_regions'))
         assert not obj.deploy()
-        assert 'Processing regions sequentially...' in \
+        assert 'deployment_1:processing regions sequentially...' in \
             caplog.messages
         mock_run.assert_has_calls([call('deploy', 'us-east-1'),
                                    call('deploy', 'us-west-2')])
@@ -245,8 +245,8 @@ class TestDeployment(object):
         assert obj.plan()
 
         if async_used:
-            assert 'Processing of regions will be done in parallel ' \
-                'during deploy/destroy.' in caplog.messages
+            assert 'deployment_1:processing of regions will be done in ' \
+                'parallel during deploy/destroy' in caplog.messages
         mock_async.assert_not_called()
         mock_sync.assert_called_once_with('plan')
 
@@ -327,7 +327,7 @@ class TestDeployment(object):
             assert obj.validate_account_credentials()
         assert excinfo.value.code == 1
         logs = '\n'.join(caplog.messages)
-        assert 'Verified current AWS account matches required account id' in logs
+        assert 'verified current AWS account matches required account id' in logs
         assert 'do not match required account alias "test"' in logs
         caplog.clear()
         del logs
@@ -336,8 +336,8 @@ class TestDeployment(object):
         account.aliases = ['test']
         assert not obj.validate_account_credentials()
         logs = '\n'.join(caplog.messages)
-        assert 'Verified current AWS account matches required account id' in logs
-        assert 'Verified current AWS account alias matches required alias' in logs
+        assert 'verified current AWS account matches required account id' in logs
+        assert 'verified current AWS account alias matches required alias' in logs
 
     @pytest.mark.parametrize('action', [('deploy'), ('destroy')])
     def test_run_list(self, action, monkeypatch, runway_context):

--- a/tests/unit/core/providers/aws/test_cli.py
+++ b/tests/unit/core/providers/aws/test_cli.py
@@ -17,7 +17,7 @@ def test_cli(mock_clidriver, caplog):
     mock_clidriver.main.return_value = 0
 
     assert not cli(['test'])
-    assert 'passing "test" to awscli...' in caplog.messages
+    assert 'passing command to awscli: test' in caplog.messages
     mock_clidriver.assert_called_once_with()
     mock_clidriver.main.assert_called_once_with(['test'])
 

--- a/tests/unit/core/test_core.py
+++ b/tests/unit/core/test_core.py
@@ -128,7 +128,7 @@ class TestRunway(object):
         obj.tests = [MagicMock(type='success'),
                      MagicMock(type='fail_system_exit_0')]
         assert not obj.test()
-        assert 'The following tests failed' not in '\n'.join(caplog.messages)
+        assert 'the following tests failed' not in '\n'.join(caplog.messages)
         test_handlers['success'].handle.assert_called_with(obj.tests[0].name,
                                                            obj.tests[0].args)
         test_handlers['fail_system_exit_0'].handle.assert_called_with(
@@ -145,9 +145,7 @@ class TestRunway(object):
         with pytest.raises(SystemExit) as excinfo:
             assert not obj.test()
         assert excinfo.value.code == 1
-        assert 'The following tests failed: fail_system_exit_1' in caplog.messages
-        assert 'Failed test was required, the remaining tests have been skipped' \
-            not in caplog.messages
+        assert 'the following tests failed: fail_system_exit_1' in caplog.messages
         test_handlers['fail_system_exit_1'].handle.assert_called_with(
             obj.tests[0].name, obj.tests[0].args
         )
@@ -162,8 +160,8 @@ class TestRunway(object):
         with pytest.raises(SystemExit) as excinfo:
             assert not obj.test()
         assert excinfo.value.code == 1
-        assert 'Test failed: exception' in caplog.messages
-        assert 'Failed test was required, the remaining tests have been skipped' \
+        assert 'exception:running test (fail)' in caplog.messages
+        assert 'exception:test required; the remaining tests have been skipped' \
             in caplog.messages
         test_handlers['exception'].handle.assert_called_with(
             obj.tests[0].name, obj.tests[0].args
@@ -183,15 +181,15 @@ class TestRunway(object):
         with pytest.raises(SystemExit) as excinfo:
             assert obj.test()
         assert excinfo.value.code == 1
-        assert 'Unable to find handler for test "test" of type "missing"' in \
+        assert 'test:unable to find handler of type "missing"' in \
             caplog.messages
-        assert 'The following tests failed: test' not in caplog.messages
+        assert 'the following tests failed: test' not in caplog.messages
 
         obj.tests[0].required = False
         with pytest.raises(SystemExit) as excinfo:
             assert obj.test()
         assert excinfo.value.code == 1
-        assert 'The following tests failed: test' in caplog.messages
+        assert 'the following tests failed: test' in caplog.messages
 
     def test_test_no_tests(self, caplog, runway_config, runway_context):
         """Test test with no tests defined."""
@@ -201,5 +199,5 @@ class TestRunway(object):
         with pytest.raises(SystemExit) as excinfo:
             assert obj.test()
         assert excinfo.value.code == 1
-        assert 'Use of "runway test" without defining tests' in \
+        assert 'no tests defined in runway.yml' in \
             caplog.messages[0]

--- a/tests/unit/module/test_module.py
+++ b/tests/unit/module/test_module.py
@@ -38,8 +38,8 @@ class TestRunwayModuleNpm(object):
         with pytest.raises(SystemExit):
             assert not obj.check_for_npm()
 
-        assert ['tests: "npm" not found in path or is not executable; '
-                'please ensure it is installed correctly.'] == \
+        assert ['"npm" not found in path or is not executable; '
+                'please ensure it is installed correctly'] == \
             caplog.messages
 
     @patch('runway.module.which')
@@ -82,8 +82,8 @@ class TestRunwayModuleNpm(object):
                                   path=tmp_path)
         assert excinfo.value.code > 0  # non-zero exit code
         assert caplog.messages == [
-            '{}: "npm" not found in path or is not executable; '
-            'please ensure it is installed correctly.'.format(tmp_path.name)
+            '"npm" not found in path or is not executable; '
+            'please ensure it is installed correctly'.format(tmp_path.name)
         ]
 
     @patch('runway.module.format_npm_command_for_logging')
@@ -94,10 +94,10 @@ class TestRunwayModuleNpm(object):
         obj = RunwayModuleNpm(context=runway_context,
                               path='./tests',
                               options={})
-        caplog.set_level(logging.INFO, logger='runway')
+        caplog.set_level(logging.DEBUG, logger='runway')
         assert not obj.log_npm_command(['npm', 'test'])
         mock_log.assert_called_once_with(['npm', 'test'])
-        assert ['tests: Running "success"'] == caplog.messages
+        assert ['node command: success'] == caplog.messages
 
     @patch('runway.module.use_npm_ci')
     @patch('runway.module.subprocess')
@@ -114,36 +114,36 @@ class TestRunwayModuleNpm(object):
 
         obj.options['skip_npm_ci'] = True
         assert not obj.npm_install()
-        expected_logs.append('tests: Skipping npm ci and npm install...')
+        expected_logs.append('skipped npm ci/npm install')
 
         obj.options['skip_npm_ci'] = False
         obj.context.env.ci = True
         mock_ci.return_value = True
         assert not obj.npm_install()
-        expected_logs.append('tests: Running npm ci...')
+        expected_logs.append('running npm ci...')
         expected_calls.append(call([NPM_BIN, 'ci']))
 
         obj.context.env.ci = False
         assert not obj.npm_install()
-        expected_logs.append('tests: Running npm install...')
+        expected_logs.append('running npm install...')
         expected_calls.append(call([NPM_BIN, 'install']))
 
         obj.context.env.ci = True
         mock_ci.return_value = False
         assert not obj.npm_install()
-        expected_logs.append('tests: Running npm install...')
+        expected_logs.append('running npm install...')
         expected_calls.append(call([NPM_BIN, 'install']))
 
         monkeypatch.setattr(runway_context, 'no_color', True)
         assert not obj.npm_install()
-        expected_logs.append('tests: Running npm install...')
+        expected_logs.append('running npm install...')
         expected_calls.append(call([NPM_BIN, 'install', '--no-color']))
 
         obj.options['skip_npm_ci'] = False
         obj.context.env.ci = True
         mock_ci.return_value = True
         assert not obj.npm_install()
-        expected_logs.append('tests: Running npm ci...')
+        expected_logs.append('running npm ci...')
         expected_calls.append(call([NPM_BIN, 'ci', '--no-color']))
 
         assert expected_logs == caplog.messages
@@ -152,14 +152,14 @@ class TestRunwayModuleNpm(object):
     def test_package_json_missing(self, caplog, patch_module_npm,
                                   runway_context, tmp_path):
         """Test package_json_missing."""
-        caplog.set_level(logging.WARNING, logger='runway')
+        caplog.set_level(logging.DEBUG, logger='runway')
         obj = RunwayModuleNpm(context=runway_context,
                               path=str(tmp_path),
                               options={})
 
         assert obj.package_json_missing()
         assert [
-            '{}: Module is missing a "package.json"'.format(tmp_path.name)
+            'module is missing package.json'.format(tmp_path.name)
         ] == caplog.messages
 
         (tmp_path / 'package.json').touch()

--- a/tests/unit/module/test_terraform.py
+++ b/tests/unit/module/test_terraform.py
@@ -212,7 +212,7 @@ class TestTerraformBackendConfig(object):
     def test_resolve_ssm_params(self, caplog, kwargs, parameters, expected):
         """Test resolve_ssm_params."""
         # this test is not compatable with python 2 due to how it handles dicts
-        caplog.set_level('WARNING', logger='runway')
+        caplog.set_level('WARNING')
 
         client = boto3.client('ssm')
         stubber = Stubber(client)
@@ -235,7 +235,7 @@ class TestTerraformBackendConfig(object):
                 client, **kwargs
             ) == expected
         stubber.assert_no_pending_responses()
-        assert 'deprecated' in caplog.records[0].msg
+        assert 'deprecated' in '\n'.join(caplog.messages)
 
     def test_gen_backend_tfvars_filenames(self):
         """Test gen_backend_tfvars_filenames."""

--- a/tests/unit/test_runway_module_type.py
+++ b/tests/unit/test_runway_module_type.py
@@ -46,8 +46,9 @@ class TestRunwayModuleType(object):
         with pytest.raises(SystemExit) as excinfo:
             assert not RunwayModuleType(str(cd_tmp_path))
         assert excinfo.value.code == 1
-        assert 'No module class found for ' + str(cd_tmp_path.name) in \
-            caplog.messages
+        assert 'module class could not be determined from path "{}"'.format(
+            cd_tmp_path.name
+        ) in caplog.messages
 
     def test_from_class_path(self, cd_tmp_path):
         """Test from class_path."""

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,7 @@
 """Test Runway utils."""
 # pylint: disable=no-self-use
 import logging
+import json
 import os
 import string
 import sys
@@ -121,7 +122,7 @@ class TestSafeHaven(object):
         orig_val = dict(os.environ)
         expected_val = dict(os.environ)
         expected_logs = ['entering a safe haven...',
-                         'resetting os.environ: %s' % orig_val,
+                         'resetting os.environ: %s' % json.dumps(orig_val),
                          'leaving the safe haven...']
 
         if isinstance(provided, dict):
@@ -163,7 +164,7 @@ class TestSafeHaven(object):
         orig_val = list(sys.argv)
         expected_val = provided if isinstance(provided, list) else list(sys.argv)
         expected_logs = ['entering a safe haven...',
-                         'resetting sys.argv: %s' % orig_val,
+                         'resetting sys.argv: %s' % json.dumps(orig_val),
                          'leaving the safe haven...']
 
         with SafeHaven(argv=provided) as obj:
@@ -216,7 +217,7 @@ class TestSafeHaven(object):
         orig_val = list(sys.path)
         expected_val = provided if isinstance(provided, list) else list(sys.path)
         expected_logs = ['entering a safe haven...',
-                         'resetting sys.path: %s' % orig_val,
+                         'resetting sys.path: %s' % json.dumps(orig_val),
                          'leaving the safe haven...']
 
         with SafeHaven(sys_path=provided) as obj:


### PR DESCRIPTION
## Why This Is Needed

- adds additional information to aid in troubleshooting
- improves consistency of log messages across the project
- reduce clutter on the info level

## What Changed

### Added

- added `--verbose` option to commands to enable verbose logging
- by default, log messages are now colored by level
- added environment variables that can be used to configure logging
- `DeployEnvionment` now has a property to track & set the value of `VERBOSE`

### Changed

- the default log message format shows the app name instead of the logger name and no longer shows the level since levels each have their own color now
	- enabling debug, verbose, or no color will instead cause `logging.BASIC_FORMAT` to be used to return the removed information
- many log messages have been updated for consistency
	- turned messages into statements rather than sentences (lower case, no period at the end)
	- log levels adjusted to use new levels (verbose, notice, success)
- CFNgin will now tail stacks when using verbose logging
- CFNgin stack tail logs now include the logical name of resources
- dependency loggers are now only setup as needed

### Fixed

- fixed an issue where tailing a stack with CFNgin could result in an exception being raised if the stack was deleted before the first tail

### Removed

## Screenshots
